### PR TITLE
Add overloads for string attribute functions

### DIFF
--- a/src/Generated.cs
+++ b/src/Generated.cs
@@ -1027,7 +1027,7 @@ namespace LLVMSharp
         public static extern uint GetMDKindID([MarshalAs(UnmanagedType.LPStr)] string @Name, uint @SLen);
 
         [DllImport(libraryPath, EntryPoint = "LLVMGetEnumAttributeKindForName", CallingConvention = CallingConvention.Cdecl)]
-        public static extern uint GetEnumAttributeKindForName([MarshalAs(UnmanagedType.LPStr)] string @Name, size_t @SLen);
+        internal static extern uint GetEnumAttributeKindForName([MarshalAs(UnmanagedType.LPStr)] string @Name, size_t @SLen);
 
         [DllImport(libraryPath, EntryPoint = "LLVMGetLastEnumAttributeKind", CallingConvention = CallingConvention.Cdecl)]
         public static extern uint GetLastEnumAttributeKind();
@@ -1042,13 +1042,13 @@ namespace LLVMSharp
         public static extern ulong GetEnumAttributeValue(LLVMAttributeRef @A);
 
         [DllImport(libraryPath, EntryPoint = "LLVMCreateStringAttribute", CallingConvention = CallingConvention.Cdecl)]
-        public static extern LLVMAttributeRef CreateStringAttribute(LLVMContextRef @C, [MarshalAs(UnmanagedType.LPStr)] string @K, uint @KLength, [MarshalAs(UnmanagedType.LPStr)] string @V, uint @VLength);
+        internal static extern LLVMAttributeRef CreateStringAttribute(LLVMContextRef @C, [MarshalAs(UnmanagedType.LPStr)] string @K, uint @KLength, [MarshalAs(UnmanagedType.LPStr)] string @V, uint @VLength);
 
         [DllImport(libraryPath, EntryPoint = "LLVMGetStringAttributeKind", CallingConvention = CallingConvention.Cdecl)]
-        public static extern string GetStringAttributeKind(LLVMAttributeRef @A, out uint @Length);
+        internal static extern string GetStringAttributeKind(LLVMAttributeRef @A, out uint @Length);
 
         [DllImport(libraryPath, EntryPoint = "LLVMGetStringAttributeValue", CallingConvention = CallingConvention.Cdecl)]
-        public static extern string GetStringAttributeValue(LLVMAttributeRef @A, out uint @Length);
+        internal static extern string GetStringAttributeValue(LLVMAttributeRef @A, out uint @Length);
 
         [DllImport(libraryPath, EntryPoint = "LLVMIsEnumAttribute", CallingConvention = CallingConvention.Cdecl)]
         public static extern LLVMBool IsEnumAttribute(LLVMAttributeRef @A);
@@ -2020,13 +2020,13 @@ namespace LLVMSharp
         public static extern LLVMAttributeRef GetEnumAttributeAtIndex(LLVMValueRef @F, LLVMAttributeIndex @Idx, uint @KindID);
 
         [DllImport(libraryPath, EntryPoint = "LLVMGetStringAttributeAtIndex", CallingConvention = CallingConvention.Cdecl)]
-        public static extern LLVMAttributeRef GetStringAttributeAtIndex(LLVMValueRef @F, LLVMAttributeIndex @Idx, [MarshalAs(UnmanagedType.LPStr)] string @K, uint @KLen);
+        internal static extern LLVMAttributeRef GetStringAttributeAtIndex(LLVMValueRef @F, LLVMAttributeIndex @Idx, [MarshalAs(UnmanagedType.LPStr)] string @K, uint @KLen);
 
         [DllImport(libraryPath, EntryPoint = "LLVMRemoveEnumAttributeAtIndex", CallingConvention = CallingConvention.Cdecl)]
         public static extern void RemoveEnumAttributeAtIndex(LLVMValueRef @F, LLVMAttributeIndex @Idx, uint @KindID);
 
         [DllImport(libraryPath, EntryPoint = "LLVMRemoveStringAttributeAtIndex", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void RemoveStringAttributeAtIndex(LLVMValueRef @F, LLVMAttributeIndex @Idx, [MarshalAs(UnmanagedType.LPStr)] string @K, uint @KLen);
+        internal static extern void RemoveStringAttributeAtIndex(LLVMValueRef @F, LLVMAttributeIndex @Idx, [MarshalAs(UnmanagedType.LPStr)] string @K, uint @KLen);
 
         [DllImport(libraryPath, EntryPoint = "LLVMAddTargetDependentFunctionAttr", CallingConvention = CallingConvention.Cdecl)]
         public static extern void AddTargetDependentFunctionAttr(LLVMValueRef @Fn, [MarshalAs(UnmanagedType.LPStr)] string @A, [MarshalAs(UnmanagedType.LPStr)] string @V);
@@ -2215,13 +2215,13 @@ namespace LLVMSharp
         public static extern LLVMAttributeRef GetCallSiteEnumAttribute(LLVMValueRef @C, LLVMAttributeIndex @Idx, uint @KindID);
 
         [DllImport(libraryPath, EntryPoint = "LLVMGetCallSiteStringAttribute", CallingConvention = CallingConvention.Cdecl)]
-        public static extern LLVMAttributeRef GetCallSiteStringAttribute(LLVMValueRef @C, LLVMAttributeIndex @Idx, [MarshalAs(UnmanagedType.LPStr)] string @K, uint @KLen);
+        internal static extern LLVMAttributeRef GetCallSiteStringAttribute(LLVMValueRef @C, LLVMAttributeIndex @Idx, [MarshalAs(UnmanagedType.LPStr)] string @K, uint @KLen);
 
         [DllImport(libraryPath, EntryPoint = "LLVMRemoveCallSiteEnumAttribute", CallingConvention = CallingConvention.Cdecl)]
         public static extern void RemoveCallSiteEnumAttribute(LLVMValueRef @C, LLVMAttributeIndex @Idx, uint @KindID);
 
         [DllImport(libraryPath, EntryPoint = "LLVMRemoveCallSiteStringAttribute", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void RemoveCallSiteStringAttribute(LLVMValueRef @C, LLVMAttributeIndex @Idx, [MarshalAs(UnmanagedType.LPStr)] string @K, uint @KLen);
+        internal static extern void RemoveCallSiteStringAttribute(LLVMValueRef @C, LLVMAttributeIndex @Idx, [MarshalAs(UnmanagedType.LPStr)] string @K, uint @KLen);
 
         [DllImport(libraryPath, EntryPoint = "LLVMGetCalledValue", CallingConvention = CallingConvention.Cdecl)]
         public static extern LLVMValueRef GetCalledValue(LLVMValueRef @Instr);

--- a/src/Overloads.cs
+++ b/src/Overloads.cs
@@ -349,6 +349,42 @@
             return arr;
         }
 
+        public static LLVMAttributeRef GetCallSiteStringAttribute(LLVMValueRef C, LLVMAttributeIndex Idx, [MarshalAs(UnmanagedType.LPStr)] string Kind) {
+            return GetCallSiteStringAttribute(C, Idx, Kind, Kind == null ? 0 : (uint)Kind.Length);
+        }
+
+        public static uint GetEnumAttributeKindForName(string Name) {
+            return GetEnumAttributeKindForName(Name, Name == null ? 0 : (uint)Name.Length);
+        }
+
+        public static LLVMAttributeRef CreateStringAttribute(LLVMContextRef C, string Kind, string Value) {
+            return CreateStringAttribute(C,
+                                         Kind, Kind == null ? 0 : (uint)Kind.Length,
+                                         Value, Value == null ? 0 : (uint)Value.Length);
+        }
+
+        public static LLVMAttributeRef GetStringAttributeAtIndex(LLVMValueRef F, LLVMAttributeIndex Idx, string Kind) {
+            return GetStringAttributeAtIndex(F, Idx, Kind, Kind == null ? 0 : (uint)Kind.Length);
+        }
+
+        public static string GetStringAttributeKind(LLVMAttributeRef A) {
+            return GetStringAttributeKind(A, out uint length);
+        }
+
+        public static string GetStringAttributeValue(LLVMAttributeRef A) {
+            return GetStringAttributeValue(A, out uint length);
+        }
+
+
+        public static void RemoveCallSiteStringAttribute(LLVMValueRef C, LLVMAttributeIndex Idx, [MarshalAs(UnmanagedType.LPStr)] string Kind) {
+            RemoveCallSiteStringAttribute(C, Idx, Kind, Kind == null ? 0 : (uint)Kind.Length);
+        }
+
+
+        public static void RemoveStringAttributeAtIndex(LLVMValueRef F, LLVMAttributeIndex Idx, string Kind) {
+            RemoveStringAttributeAtIndex(F, Idx, Kind, Kind == null ? 0 : (uint)Kind.Length);
+        }
+
         public static LLVMBool VerifyModule(LLVMModuleRef M, LLVMVerifierFailureAction Action, out string OutMessage)
         {
             var retVal = VerifyModule(M, Action, out IntPtr message);


### PR DESCRIPTION
Hi,
several functions of the LLVM C-API for handling attributes
take string arguments. In the C-API,
a string is represented as a pointer
together with the length of the string.
This representation is currently exposed
in the LLVMSharp methods.

This commit adds overloads for the
corresponding methods which hide
the unnecessary length arguments.