### PR TITLE
Make dotnet test execute only test projects

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,9 @@
+<Project>
+  <Target Name="VSTestIfTestProject">
+    <!-- Change VSTest to call only projects where IsTestProject is defined.
+         This gets defined in Microsoft.NET.Test.Sdk and hence 
+         VSTest is run only on test projects. -->
+    <CallTarget Targets="VSTest" Condition="'$(IsTestProject)' == 'true'" />
+  </Target>
+</Project>
+

--- a/after.LLVMSharp.sln.targets
+++ b/after.LLVMSharp.sln.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="VSTest">
+    <MSBuild Projects="@(ProjectReference)" Targets="VSTestIfTestProject" />
+  </Target>
+</Project>


### PR DESCRIPTION
This change modifies the VSTest target to ensure
that the VSTest target gets executed for test projects
only. It seems that msbuild has been extended
by a way to specify that a project is a test project
very recently, see [this issue](https://github.com/dotnet/cli/issues/7447).
I think that, for now, it is better to use the workaround that
has been described in this issue and which has been explained
in detail [here](https://dasmulli.blog/2018/01/20/make-dotnet-test-work-on-solution-files/).