### PR TITLE
Remove test filename from Travis configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ cache:
 script:
   - dotnet restore
   - dotnet build
-  - dotnet test Tests/LLVMSharp.Tests.csproj
+  - dotnet test


### PR DESCRIPTION
Just `dotnet test` can find and run the tests now, so I've removed the test project filename from the YAML file.