### PR TITLE
Fix string marshaling crash.

### DIFF
--- a/Tests/Bindings.cs
+++ b/Tests/Bindings.cs
@@ -1,0 +1,52 @@
+﻿namespace LLVMSharp.Tests
+{
+    using NUnit.Framework;
+    using System;
+
+    public class Bindings
+    {
+        [Test]
+        public void StringMarshaling()
+        {
+            var mod = LLVM.ModuleCreateWithName("string_marshaling_test");
+
+            var param_types = new LLVMTypeRef[0];
+            var func_type = LLVM.FunctionType(LLVM.Int32Type(), param_types, false);
+            var main = LLVM.AddFunction(mod, "main", func_type);
+
+            const string BasicBlockName = "entry";
+            var entry = LLVM.AppendBasicBlock(main, BasicBlockName);
+
+            var builder = LLVM.CreateBuilder();
+            LLVM.PositionBuilderAtEnd(builder, entry);
+            var ret = LLVM.BuildRet(builder, LLVM.ConstInt(LLVM.Int32Type(), 0ul, new LLVMBool(false)));
+
+            if (LLVM.VerifyModule(mod, LLVMVerifierFailureAction.LLVMPrintMessageAction, out var error) != new LLVMBool(true))
+            {
+                Console.WriteLine($"Error: {error}");
+            }
+
+            var basicBlockName = LLVM.GetBasicBlockName(entry);
+            Assert.AreEqual(BasicBlockName, basicBlockName);
+
+            var valueName = LLVM.GetValueName(ret);
+            Assert.IsEmpty(valueName);
+
+            var layout = LLVM.GetDataLayout(mod);
+            Assert.IsEmpty(layout);
+
+            var moduleTarget = LLVM.GetTarget(mod);
+            Assert.IsEmpty(moduleTarget);
+
+            LLVM.InitializeX86TargetInfo();
+
+            var targetName = LLVM.GetTargetName(LLVM.GetFirstTarget());
+            Assert.IsTrue(targetName.Contains("x86"));
+
+            var targetDescription = LLVM.GetTargetDescription(LLVM.GetFirstTarget());
+            Assert.IsNotEmpty(targetDescription);
+
+            LLVM.DisposeBuilder(builder);
+        }
+    }
+}

--- a/src/Generated.cs
+++ b/src/Generated.cs
@@ -1150,14 +1150,8 @@ namespace LLVMSharp
         [DllImport(libraryPath, EntryPoint = "LLVMGetDataLayoutStr", CallingConvention = CallingConvention.Cdecl)]
         public static extern string GetDataLayoutStr(LLVMModuleRef @M);
 
-        [DllImport(libraryPath, EntryPoint = "LLVMGetDataLayout", CallingConvention = CallingConvention.Cdecl)]
-        public static extern string GetDataLayout(LLVMModuleRef @M);
-
         [DllImport(libraryPath, EntryPoint = "LLVMSetDataLayout", CallingConvention = CallingConvention.Cdecl)]
         public static extern void SetDataLayout(LLVMModuleRef @M, [MarshalAs(UnmanagedType.LPStr)] string @DataLayoutStr);
-
-        [DllImport(libraryPath, EntryPoint = "LLVMGetTarget", CallingConvention = CallingConvention.Cdecl)]
-        public static extern string GetTarget(LLVMModuleRef @M);
 
         [DllImport(libraryPath, EntryPoint = "LLVMSetTarget", CallingConvention = CallingConvention.Cdecl)]
         public static extern void SetTarget(LLVMModuleRef @M, [MarshalAs(UnmanagedType.LPStr)] string @Triple);
@@ -1404,9 +1398,6 @@ namespace LLVMSharp
 
         [DllImport(libraryPath, EntryPoint = "LLVMGetValueKind", CallingConvention = CallingConvention.Cdecl)]
         public static extern LLVMValueKind GetValueKind(LLVMValueRef @Val);
-
-        [DllImport(libraryPath, EntryPoint = "LLVMGetValueName", CallingConvention = CallingConvention.Cdecl)]
-        public static extern string GetValueName(LLVMValueRef @Val);
 
         [DllImport(libraryPath, EntryPoint = "LLVMSetValueName", CallingConvention = CallingConvention.Cdecl)]
         public static extern void SetValueName(LLVMValueRef @Val, [MarshalAs(UnmanagedType.LPStr)] string @Name);
@@ -2172,9 +2163,6 @@ namespace LLVMSharp
 
         [DllImport(libraryPath, EntryPoint = "LLVMValueAsBasicBlock", CallingConvention = CallingConvention.Cdecl)]
         public static extern LLVMBasicBlockRef ValueAsBasicBlock(LLVMValueRef @Val);
-
-        [DllImport(libraryPath, EntryPoint = "LLVMGetBasicBlockName", CallingConvention = CallingConvention.Cdecl)]
-        public static extern string GetBasicBlockName(LLVMBasicBlockRef @BB);
 
         [DllImport(libraryPath, EntryPoint = "LLVMGetBasicBlockParent", CallingConvention = CallingConvention.Cdecl)]
         public static extern LLVMValueRef GetBasicBlockParent(LLVMBasicBlockRef @BB);
@@ -3162,12 +3150,6 @@ namespace LLVMSharp
 
         [DllImport(libraryPath, EntryPoint = "LLVMGetTargetFromTriple", CallingConvention = CallingConvention.Cdecl)]
         internal static extern LLVMBool GetTargetFromTriple([MarshalAs(UnmanagedType.LPStr)] string @Triple, out LLVMTargetRef @T, out IntPtr @ErrorMessage);
-
-        [DllImport(libraryPath, EntryPoint = "LLVMGetTargetName", CallingConvention = CallingConvention.Cdecl)]
-        public static extern string GetTargetName(LLVMTargetRef @T);
-
-        [DllImport(libraryPath, EntryPoint = "LLVMGetTargetDescription", CallingConvention = CallingConvention.Cdecl)]
-        public static extern string GetTargetDescription(LLVMTargetRef @T);
 
         [DllImport(libraryPath, EntryPoint = "LLVMTargetHasJIT", CallingConvention = CallingConvention.Cdecl)]
         public static extern LLVMBool TargetHasJIT(LLVMTargetRef @T);

--- a/src/Overloads.Interop.cs
+++ b/src/Overloads.Interop.cs
@@ -7,17 +7,26 @@
     {
         [DllImport(libraryPath, EntryPoint = "LLVMGetValueName", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr GetValueNameAsPtr(LLVMValueRef @Val);
-
-        [DllImport(libraryPath, EntryPoint = "LLVMGetTarget", CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr GetTargetAsPtr(LLVMModuleRef M);
+        public static string GetValueName(LLVMValueRef @Val) => Marshal.PtrToStringAnsi(GetValueNameAsPtr(@Val));
 
         [DllImport(libraryPath, EntryPoint = "LLVMGetDataLayout", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr GetDataLayoutAsPtr(LLVMModuleRef M);
+        public static string GetDataLayout(LLVMModuleRef M) => Marshal.PtrToStringAnsi(GetDataLayoutAsPtr(M));
+
+        [DllImport(libraryPath, EntryPoint = "LLVMGetTarget", CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr GetTargetAsPtr(LLVMModuleRef M);
+        public static string GetTarget(LLVMModuleRef M) => Marshal.PtrToStringAnsi(GetTargetAsPtr(M));
 
         [DllImport(libraryPath, EntryPoint = "LLVMGetTargetName", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr GetTargetNameAsPtr(LLVMTargetRef @T);
+        public static string GetTargetName(LLVMTargetRef @T) => Marshal.PtrToStringAnsi(GetTargetNameAsPtr(@T));
 
         [DllImport(libraryPath, EntryPoint = "LLVMGetTargetDescription", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr GetTargetDescriptionAsPtr(LLVMTargetRef @T);
+        public static string GetTargetDescription(LLVMTargetRef @T) => Marshal.PtrToStringAnsi(GetTargetDescriptionAsPtr(@T));
+
+        [DllImport(libraryPath, EntryPoint = "LLVMGetBasicBlockName", CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr GetBasicBlockNameAsPtr(LLVMBasicBlockRef @BB);
+        public static string GetBasicBlockName(LLVMBasicBlockRef @BB) => Marshal.PtrToStringAnsi(GetBasicBlockNameAsPtr(@BB));        
     }
 }


### PR DESCRIPTION
This PR fixes a string marshaling issue that causes a crash in #90 (among other cases).

The fix is achieved by:
- Locating various `extern` methods  that return a `string` (such as `LLVM.GetBasicBlockName`).
- Adding an alternative version that returns an `IntPtr` (e.g. `GetBasicBlockNameAsPtr`).
- Changing the original `extern` method to call the alternative version and pass the pointer to `Marshal.PtrToStringAnsi`.

I have moved the offending methods to `Overloads.Interop.cs`, to keep them separate from the generated ones that don't need this kind of attention.

Some classes in `LLVMSharp.API` were already performing this fix internally, in order to provide a safer debugging experience (otherwise viewing properties would crash the debugger). This PR simply brings that safety to the bindings as well.