### PR TITLE
Ensure that LLVMTypeRef passes parameters down properly

### DIFF
--- a/Tests/LLVMSharp.UnitTests/Functions.cs
+++ b/Tests/LLVMSharp.UnitTests/Functions.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+using NUnit.Framework;
+
+namespace LLVMSharp.UnitTests
+{
+    public class Functions
+    {
+        [Test]
+        public void ParamTypesRoundtrip()
+        {
+            var returnType = LLVMTypeRef.Int8;
+            var parameterTypes = new[] { LLVMTypeRef.Double };
+            var functionType = LLVMTypeRef.CreateFunction(returnType, parameterTypes);
+            Assert.AreEqual(parameterTypes, functionType.ParamTypes);
+        }
+    }
+}

--- a/sources/LLVMSharp/Interop.Extensions/LLVMTypeRef.cs
+++ b/sources/LLVMSharp/Interop.Extensions/LLVMTypeRef.cs
@@ -84,7 +84,7 @@ namespace LLVMSharp.Interop
 
                 fixed (LLVMTypeRef* pDest = Dest)
                 {
-                    LLVM.GetParamTypes(this, (LLVMOpaqueType**)&pDest);
+                    LLVM.GetParamTypes(this, (LLVMOpaqueType**)pDest);
                 }
 
                 return Dest;
@@ -112,7 +112,7 @@ namespace LLVMSharp.Interop
 
                 fixed (LLVMTypeRef* pDest = Dest)
                 {
-                    LLVM.GetStructElementTypes(this, (LLVMOpaqueType**)&pDest);
+                    LLVM.GetStructElementTypes(this, (LLVMOpaqueType**)pDest);
                 }
 
                 return Dest;
@@ -155,7 +155,7 @@ namespace LLVMSharp.Interop
 
                 fixed (LLVMTypeRef* pArr = Arr)
                 {
-                    LLVM.GetSubtypes(this, (LLVMOpaqueType**)&pArr);
+                    LLVM.GetSubtypes(this, (LLVMOpaqueType**)pArr);
                 }
 
                 return Arr;


### PR DESCRIPTION
This resolves #134. LLVMTypeRef had three methods which were adding an additional indirection where it was not needed.