### PR TITLE
Adding span overloads for most of the interop extensions

### DIFF
--- a/sources/LLVMSharp/Internals/MarshaledArray`1.cs
+++ b/sources/LLVMSharp/Internals/MarshaledArray`1.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using System;
+using System.Buffers;
+
+namespace LLVMSharp
+{
+    internal unsafe struct MarshaledArray<T, U> : IDisposable
+    {
+        public MarshaledArray(ReadOnlySpan<T> inputs, Func<T, U> marshal)
+        {
+            if (inputs.IsEmpty)
+            {
+                Count = 0;
+                Values = null;
+            }
+            else
+            {
+                Count = inputs.Length;
+                Values = ArrayPool<U>.Shared.Rent(Count);
+
+                for (int i = 0; i < Count; i++)
+                {
+                    Values[i] = marshal(inputs[i]);
+                }
+            }
+        }
+
+        public int Count { get; private set; }
+
+        public U[] Values { get; private set; }
+
+        public static implicit operator ReadOnlySpan<U>(in MarshaledArray<T, U> value)
+        {
+            return value.Values;
+        }
+
+        public void Dispose()
+        {
+            if (Values != null)
+            {
+                ArrayPool<U>.Shared.Return(Values);
+            }
+        }
+    }
+}

--- a/sources/LLVMSharp/Internals/MarshaledString.cs
+++ b/sources/LLVMSharp/Internals/MarshaledString.cs
@@ -8,9 +8,9 @@ namespace LLVMSharp
 {
     internal unsafe struct MarshaledString : IDisposable
     {
-        public MarshaledString(string input)
+        public MarshaledString(ReadOnlySpan<char> input)
         {
-            if ((input is null) || (input.Length == 0))
+            if (input.IsEmpty)
             {
                 var value = Marshal.AllocHGlobal(1);
                 Marshal.WriteByte(value, 0, 0);
@@ -20,7 +20,7 @@ namespace LLVMSharp
             }
             else
             {
-                var valueBytes = Encoding.UTF8.GetBytes(input);
+                var valueBytes = Encoding.UTF8.GetBytes(input.ToString());
                 var length = valueBytes.Length;
                 var value = Marshal.AllocHGlobal(length + 1);
                 Marshal.Copy(valueBytes, 0, value, length);

--- a/sources/LLVMSharp/Internals/MarshaledStringArray.cs
+++ b/sources/LLVMSharp/Internals/MarshaledStringArray.cs
@@ -6,9 +6,9 @@ namespace LLVMSharp
 {
     internal unsafe struct MarshaledStringArray : IDisposable
     {
-        public MarshaledStringArray(string[] inputs)
+        public MarshaledStringArray(ReadOnlySpan<string> inputs)
         {
-            if ((inputs is null) || (inputs.Length == 0))
+            if (inputs.IsEmpty)
             {
                 Count = 0;
                 Values = null;
@@ -20,7 +20,7 @@ namespace LLVMSharp
 
                 for (int i = 0; i < Count; i++)
                 {
-                    Values[i] = new MarshaledString(inputs[i]);
+                    Values[i] = new MarshaledString(inputs[i].AsSpan());
                 }
             }
         }

--- a/sources/LLVMSharp/Interop.Extensions/LLVMBasicBlockRef.cs
+++ b/sources/LLVMSharp/Interop.Extensions/LLVMBasicBlockRef.cs
@@ -49,6 +49,30 @@ namespace LLVMSharp.Interop
 
         public static bool operator !=(LLVMBasicBlockRef left, LLVMBasicBlockRef right) => !(left == right);
 
+        public static LLVMBasicBlockRef AppendInContext(LLVMContextRef C, LLVMValueRef Fn, string Name) => AppendInContext(C, Fn, Name.AsSpan());
+
+        public static LLVMBasicBlockRef AppendInContext(LLVMContextRef C, LLVMValueRef Fn, ReadOnlySpan<char> Name)
+        {
+            using var marshaledName = new MarshaledString(Name);
+            return LLVM.AppendBasicBlockInContext(C, Fn, marshaledName);
+        }
+
+        public static LLVMBasicBlockRef CreateInContext(LLVMContextRef C, string Name) => CreateInContext(C, Name.AsSpan());
+
+        public static LLVMBasicBlockRef CreateInContext(LLVMContextRef C, ReadOnlySpan<char> Name)
+        {
+            using var marshaledName = new MarshaledString(Name);
+            return LLVM.CreateBasicBlockInContext(C, marshaledName);
+        }
+
+        public static LLVMBasicBlockRef InsertInContext(LLVMContextRef C, LLVMBasicBlockRef BB, string Name) => InsertInContext(C, BB, Name.AsSpan());
+
+        public static LLVMBasicBlockRef InsertInContext(LLVMContextRef C, LLVMBasicBlockRef BB, ReadOnlySpan<char> Name)
+        {
+            using var marshaledName = new MarshaledString(Name);
+            return LLVM.InsertBasicBlockInContext(C, BB, marshaledName);
+        }
+
         public LLVMValueRef AsValue() => LLVM.BasicBlockAsValue(this);
 
         public void Delete() => LLVM.DeleteBasicBlock(this);
@@ -61,7 +85,9 @@ namespace LLVMSharp.Interop
 
         public override int GetHashCode() => Handle.GetHashCode();
 
-        public LLVMBasicBlockRef InsertBasicBlock(string Name)
+        public LLVMBasicBlockRef InsertBasicBlock(string Name) => InsertBasicBlock(Name.AsSpan());
+
+        public LLVMBasicBlockRef InsertBasicBlock(ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.InsertBasicBlock(this, marshaledName);

--- a/sources/LLVMSharp/Interop.Extensions/LLVMBuilderRef.cs
+++ b/sources/LLVMSharp/Interop.Extensions/LLVMBuilderRef.cs
@@ -35,51 +35,69 @@ namespace LLVMSharp.Interop
 
         public static bool operator !=(LLVMBuilderRef left, LLVMBuilderRef right) => !(left == right);
 
-        public LLVMValueRef BuildAdd(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public static LLVMBuilderRef Create(LLVMContextRef C) => LLVM.CreateBuilderInContext(C);
+
+        public LLVMValueRef BuildAdd(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildAdd(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildAdd(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildAdd(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildAddrSpaceCast(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildAddrSpaceCast(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildAddrSpaceCast(Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildAddrSpaceCast(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildAddrSpaceCast(this, Val, DestTy, marshaledName);
         }
 
-        public LLVMValueRef BuildAggregateRet(LLVMValueRef[] RetVals)
+        public LLVMValueRef BuildAggregateRet(LLVMValueRef[] RetVals) => BuildAggregateRet(RetVals.AsSpan());
+
+        public LLVMValueRef BuildAggregateRet(ReadOnlySpan<LLVMValueRef> RetVals)
         {
             fixed (LLVMValueRef* pRetVals = RetVals)
             {
-                return LLVM.BuildAggregateRet(this, (LLVMOpaqueValue**)pRetVals, (uint)RetVals?.Length);
+                return LLVM.BuildAggregateRet(this, (LLVMOpaqueValue**)pRetVals, (uint)RetVals.Length);
             }
         }
 
-        public LLVMValueRef BuildAlloca(LLVMTypeRef Ty, string Name = "")
+        public LLVMValueRef BuildAlloca(LLVMTypeRef Ty, string Name = "") => BuildAlloca(Ty, Name.AsSpan());
+
+        public LLVMValueRef BuildAlloca(LLVMTypeRef Ty, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildAlloca(this, Ty, marshaledName);
         }
 
-        public LLVMValueRef BuildAnd(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildAnd(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildAnd(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildAnd(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildAnd(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildArrayAlloca(LLVMTypeRef Ty, LLVMValueRef Val, string Name = "")
+        public LLVMValueRef BuildArrayAlloca(LLVMTypeRef Ty, LLVMValueRef Val, string Name = "") => BuildArrayAlloca(Ty, Val, Name.AsSpan());
+
+        public LLVMValueRef BuildArrayAlloca(LLVMTypeRef Ty, LLVMValueRef Val, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildArrayAlloca(this, Ty, Val, marshaledName);
         }
 
-        public LLVMValueRef BuildArrayMalloc(LLVMTypeRef Ty, LLVMValueRef Val, string Name = "")
+        public LLVMValueRef BuildArrayMalloc(LLVMTypeRef Ty, LLVMValueRef Val, string Name = "") => BuildArrayMalloc(Ty, Val, Name.AsSpan());
+
+        public LLVMValueRef BuildArrayMalloc(LLVMTypeRef Ty, LLVMValueRef Val, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildArrayMalloc(this, Ty, Val, marshaledName);
         }
 
-        public LLVMValueRef BuildAShr(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildAShr(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildAShr(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildAShr(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildAShr(this, LHS, RHS, marshaledName);
@@ -87,13 +105,17 @@ namespace LLVMSharp.Interop
 
         public LLVMValueRef BuildAtomicRMW(LLVMAtomicRMWBinOp op, LLVMValueRef PTR, LLVMValueRef Val, LLVMAtomicOrdering ordering, bool singleThread) => LLVM.BuildAtomicRMW(this, op, PTR, Val, ordering, singleThread ? 1 : 0);
 
-        public LLVMValueRef BuildBinOp(LLVMOpcode Op, LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildBinOp(LLVMOpcode Op, LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildBinOp(Op, LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildBinOp(LLVMOpcode Op, LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildBinOp(this, Op, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildBitCast(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildBitCast(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildBitCast(Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildBitCast(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildBitCast(this, Val, DestTy, marshaledName);
@@ -101,16 +123,20 @@ namespace LLVMSharp.Interop
 
         public LLVMValueRef BuildBr(LLVMBasicBlockRef Dest) => LLVM.BuildBr(this, Dest);
 
-        public LLVMValueRef BuildCall(LLVMValueRef Fn, LLVMValueRef[] Args, string Name = "")
+        public LLVMValueRef BuildCall(LLVMValueRef Fn, LLVMValueRef[] Args, string Name = "") => BuildCall(Fn, Args.AsSpan(), Name.AsSpan());
+
+        public LLVMValueRef BuildCall(LLVMValueRef Fn, ReadOnlySpan<LLVMValueRef> Args, ReadOnlySpan<char> Name)
         {
             fixed (LLVMValueRef* pArgs = Args)
             {
                 using var marshaledName = new MarshaledString(Name);
-                return LLVM.BuildCall(this, Fn, (LLVMOpaqueValue**)pArgs, (uint)Args?.Length, marshaledName);
+                return LLVM.BuildCall(this, Fn, (LLVMOpaqueValue**)pArgs, (uint)Args.Length, marshaledName);
             }
         }
 
-        public LLVMValueRef BuildCast(LLVMOpcode Op, LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildCast(LLVMOpcode Op, LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildCast(Op, Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildCast(LLVMOpcode Op, LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildCast(this, Op, Val, DestTy, marshaledName);
@@ -118,85 +144,113 @@ namespace LLVMSharp.Interop
 
         public LLVMValueRef BuildCondBr(LLVMValueRef If, LLVMBasicBlockRef Then, LLVMBasicBlockRef Else) => LLVM.BuildCondBr(this, If, Then, Else);
 
-        public LLVMValueRef BuildExactSDiv(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildExactSDiv(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildExactSDiv(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildExactSDiv(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildExactSDiv(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildExtractElement(LLVMValueRef VecVal, LLVMValueRef Index, string Name = "")
+        public LLVMValueRef BuildExtractElement(LLVMValueRef VecVal, LLVMValueRef Index, string Name = "") => BuildExtractElement(VecVal, Index, Name.AsSpan());
+
+        public LLVMValueRef BuildExtractElement(LLVMValueRef VecVal, LLVMValueRef Index, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildExtractElement(this, VecVal, Index, marshaledName);
         }
 
-        public LLVMValueRef BuildExtractValue(LLVMValueRef AggVal, uint Index, string Name = "")
+        public LLVMValueRef BuildExtractValue(LLVMValueRef AggVal, uint Index, string Name = "") => BuildExtractValue(AggVal, Index, Name.AsSpan());
+
+        public LLVMValueRef BuildExtractValue(LLVMValueRef AggVal, uint Index, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildExtractValue(this, AggVal, Index, marshaledName);
         }
 
-        public LLVMValueRef BuildFAdd(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildFAdd(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildFAdd(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildFAdd(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildFAdd(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildFCmp(LLVMRealPredicate Op, LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildFCmp(LLVMRealPredicate Op, LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildFCmp(Op, LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildFCmp(LLVMRealPredicate Op, LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildFCmp(this, Op, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildFDiv(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildFDiv(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildFDiv(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildFDiv(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildFDiv(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildFence(LLVMAtomicOrdering ordering, bool singleThread, string Name = "")
+        public LLVMValueRef BuildFence(LLVMAtomicOrdering ordering, bool singleThread, string Name = "") => BuildFence(ordering, singleThread, Name.AsSpan());
+
+        public LLVMValueRef BuildFence(LLVMAtomicOrdering ordering, bool singleThread, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildFence(this, ordering, singleThread ? 1 : 0, marshaledName);
         }
 
-        public LLVMValueRef BuildFMul(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildFMul(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildFMul(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildFMul(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildFMul(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildFNeg(LLVMValueRef V, string Name = "")
+        public LLVMValueRef BuildFNeg(LLVMValueRef V, string Name = "") => BuildFNeg(V, Name.AsSpan());
+
+        public LLVMValueRef BuildFNeg(LLVMValueRef V, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildFNeg(this, V, marshaledName);
         }
 
-        public LLVMValueRef BuildFPCast(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildFPCast(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildFPCast(Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildFPCast(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildFPCast(this, Val, DestTy, marshaledName);
         }
 
-        public LLVMValueRef BuildFPExt(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildFPExt(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildFPCast(Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildFPExt(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildFPExt(this, Val, DestTy, marshaledName);
         }
 
-        public LLVMValueRef BuildFPToSI(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildFPToSI(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildFPToSI(Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildFPToSI(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildFPToSI(this, Val, DestTy, marshaledName);
         }
 
-        public LLVMValueRef BuildFPToUI(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildFPToUI(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildFPToUI(Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildFPToUI(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildFPToUI(this, Val, DestTy, marshaledName);
         }
 
-        public LLVMValueRef BuildFPTrunc(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildFPTrunc(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildFPTrunc(Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildFPTrunc(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildFPTrunc(this, Val, DestTy, marshaledName);
@@ -204,224 +258,294 @@ namespace LLVMSharp.Interop
 
         public LLVMValueRef BuildFree(LLVMValueRef PointerVal) => LLVM.BuildFree(this, PointerVal);
 
-        public LLVMValueRef BuildFreeze(LLVMValueRef Val, string Name = "")
+        public LLVMValueRef BuildFreeze(LLVMValueRef Val, string Name = "") => BuildFreeze(Val, Name.AsSpan());
+
+        public LLVMValueRef BuildFreeze(LLVMValueRef Val, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildFreeze(this, Val, marshaledName);
         }
 
-        public LLVMValueRef BuildFRem(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildFRem(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildFRem(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildFRem(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildFRem(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildFSub(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildFSub(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildFSub(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildFSub(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildFSub(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildGEP(LLVMValueRef Pointer, LLVMValueRef[] Indices, string Name = "")
+        public LLVMValueRef BuildGEP(LLVMValueRef Pointer, LLVMValueRef[] Indices, string Name = "") => BuildGEP(Pointer, Indices.AsSpan(), Name.AsSpan());
+
+        public LLVMValueRef BuildGEP(LLVMValueRef Pointer, ReadOnlySpan<LLVMValueRef> Indices, ReadOnlySpan<char> Name)
         {
             fixed (LLVMValueRef* pIndices = Indices)
             {
                 using var marshaledName = new MarshaledString(Name);
-                return LLVM.BuildGEP(this, Pointer, (LLVMOpaqueValue**)pIndices, (uint)Indices?.Length, marshaledName);
+                return LLVM.BuildGEP(this, Pointer, (LLVMOpaqueValue**)pIndices, (uint)Indices.Length, marshaledName);
             }
         }
 
-        public LLVMValueRef BuildGlobalString(string Str, string Name = "")
+        public LLVMValueRef BuildGlobalString(string Str, string Name = "") => BuildGlobalString(Str.AsSpan(), Name.AsSpan());
+
+        public LLVMValueRef BuildGlobalString(ReadOnlySpan<char> Str, ReadOnlySpan<char> Name)
         {
             using var marshaledStr = new MarshaledString(Str);
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildGlobalString(this, marshaledStr, marshaledName);
         }
 
-        public LLVMValueRef BuildGlobalStringPtr(string Str, string Name = "")
+        public LLVMValueRef BuildGlobalStringPtr(string Str, string Name = "") => BuildGlobalStringPtr(Str.AsSpan(), Name.AsSpan());
+
+        public LLVMValueRef BuildGlobalStringPtr(ReadOnlySpan<char> Str, ReadOnlySpan<char> Name)
         {
             using var marshaledStr = new MarshaledString(Str);
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildGlobalStringPtr(this, marshaledStr, marshaledName);
         }
 
-        public LLVMValueRef BuildICmp(LLVMIntPredicate Op, LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildICmp(LLVMIntPredicate Op, LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildICmp(Op, LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildICmp(LLVMIntPredicate Op, LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildICmp(this, Op, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildInBoundsGEP(LLVMValueRef Pointer, LLVMValueRef[] Indices, string Name = "")
+        public LLVMValueRef BuildInBoundsGEP(LLVMValueRef Pointer, LLVMValueRef[] Indices, string Name = "") => BuildInBoundsGEP(Pointer, Indices.AsSpan(), Name.AsSpan());
+
+        public LLVMValueRef BuildInBoundsGEP(LLVMValueRef Pointer, ReadOnlySpan<LLVMValueRef> Indices, ReadOnlySpan<char> Name)
         {
             fixed (LLVMValueRef* pIndices = Indices)
             {
                 using var marshaledName = new MarshaledString(Name);
-                return LLVM.BuildInBoundsGEP(this, Pointer, (LLVMOpaqueValue**)pIndices, (uint)Indices?.Length, marshaledName);
+                return LLVM.BuildInBoundsGEP(this, Pointer, (LLVMOpaqueValue**)pIndices, (uint)Indices.Length, marshaledName);
             }
         }
 
         public LLVMValueRef BuildIndirectBr(LLVMValueRef Addr, uint NumDests) => LLVM.BuildIndirectBr(this, Addr, NumDests);
 
-        public LLVMValueRef BuildInsertElement(LLVMValueRef VecVal, LLVMValueRef EltVal, LLVMValueRef Index, string Name = "")
+        public LLVMValueRef BuildInsertElement(LLVMValueRef VecVal, LLVMValueRef EltVal, LLVMValueRef Index, string Name = "") => BuildInsertElement(VecVal, EltVal, Index, Name.AsSpan());
+
+        public LLVMValueRef BuildInsertElement(LLVMValueRef VecVal, LLVMValueRef EltVal, LLVMValueRef Index, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildInsertElement(this, VecVal, EltVal, Index, marshaledName);
         }
 
-        public LLVMValueRef BuildInsertValue(LLVMValueRef AggVal, LLVMValueRef EltVal, uint Index, string Name = "")
+        public LLVMValueRef BuildInsertValue(LLVMValueRef AggVal, LLVMValueRef EltVal, uint Index, string Name = "") => BuildInsertValue(AggVal, EltVal, Index, Name.AsSpan());
+
+        public LLVMValueRef BuildInsertValue(LLVMValueRef AggVal, LLVMValueRef EltVal, uint Index, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildInsertValue(this, AggVal, EltVal, Index, marshaledName);
         }
 
-        public LLVMValueRef BuildIntCast(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildIntCast(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildIntCast(Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildIntCast(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildIntCast(this, Val, DestTy, marshaledName);
         }
 
-        public LLVMValueRef BuildIntToPtr(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildIntToPtr(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildIntToPtr(Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildIntToPtr(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildIntToPtr(this, Val, DestTy, marshaledName);
         }
 
-        public LLVMValueRef BuildInvoke(LLVMValueRef Fn, LLVMValueRef[] Args, LLVMBasicBlockRef Then, LLVMBasicBlockRef Catch, string Name = "")
+        public LLVMValueRef BuildInvoke(LLVMValueRef Fn, LLVMValueRef[] Args, LLVMBasicBlockRef Then, LLVMBasicBlockRef Catch, string Name = "") => BuildInvoke(Fn, Args.AsSpan(), Then, Catch, Name.AsSpan());
+
+        public LLVMValueRef BuildInvoke(LLVMValueRef Fn, ReadOnlySpan<LLVMValueRef> Args, LLVMBasicBlockRef Then, LLVMBasicBlockRef Catch, ReadOnlySpan<char> Name)
         {
             fixed (LLVMValueRef* pArgs = Args)
             {
                 using var marshaledName = new MarshaledString(Name);
-                return LLVM.BuildInvoke(this, Fn, (LLVMOpaqueValue**)pArgs, (uint)Args?.Length, Then, Catch, marshaledName);
+                return LLVM.BuildInvoke(this, Fn, (LLVMOpaqueValue**)pArgs, (uint)Args.Length, Then, Catch, marshaledName);
             }
         }
 
-        public LLVMValueRef BuildIsNotNull(LLVMValueRef Val, string Name = "")
+        public LLVMValueRef BuildIsNotNull(LLVMValueRef Val, string Name = "") => BuildIsNotNull(Val, Name.AsSpan());
+
+        public LLVMValueRef BuildIsNotNull(LLVMValueRef Val, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildIsNotNull(this, Val, marshaledName);
         }
 
-        public LLVMValueRef BuildIsNull(LLVMValueRef Val, string Name = "")
+        public LLVMValueRef BuildIsNull(LLVMValueRef Val, string Name = "") => BuildIsNull(Val, Name.AsSpan());
+
+        public LLVMValueRef BuildIsNull(LLVMValueRef Val, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildIsNull(this, Val, marshaledName);
         }
 
-        public LLVMValueRef BuildLandingPad(LLVMTypeRef Ty, LLVMValueRef PersFn, uint NumClauses, string Name = "")
+        public LLVMValueRef BuildLandingPad(LLVMTypeRef Ty, LLVMValueRef PersFn, uint NumClauses, string Name = "") => BuildLandingPad(Ty, PersFn, NumClauses, Name.AsSpan());
+
+        public LLVMValueRef BuildLandingPad(LLVMTypeRef Ty, LLVMValueRef PersFn, uint NumClauses, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildLandingPad(this, Ty, PersFn, NumClauses, marshaledName);
         }
 
-        public LLVMValueRef BuildLoad(LLVMValueRef PointerVal, string Name = "")
+        public LLVMValueRef BuildLoad(LLVMValueRef PointerVal, string Name = "") => BuildLoad(PointerVal, Name.AsSpan());
+
+        public LLVMValueRef BuildLoad(LLVMValueRef PointerVal, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildLoad(this, PointerVal, marshaledName);
         }
 
-        public LLVMValueRef BuildLShr(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildLShr(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildLShr(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildLShr(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildLShr(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildMalloc(LLVMTypeRef Ty, string Name = "")
+        public LLVMValueRef BuildMalloc(LLVMTypeRef Ty, string Name = "") => BuildMalloc(Ty, Name.AsSpan());
+
+        public LLVMValueRef BuildMalloc(LLVMTypeRef Ty, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildMalloc(this, Ty, marshaledName);
         }
 
-        public LLVMValueRef BuildMul(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildMul(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildMul(LHS, RHS, Name);
+
+        public LLVMValueRef BuildMul(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildMul(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildNeg(LLVMValueRef V, string Name = "")
+        public LLVMValueRef BuildNeg(LLVMValueRef V, string Name = "") => BuildNeg(V, Name.AsSpan());
+
+        public LLVMValueRef BuildNeg(LLVMValueRef V, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildNeg(this, V, marshaledName);
         }
 
-        public LLVMValueRef BuildNot(LLVMValueRef V, string Name = "")
+        public LLVMValueRef BuildNot(LLVMValueRef V, string Name = "") => BuildNot(V, Name.AsSpan());
+
+        public LLVMValueRef BuildNot(LLVMValueRef V, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildNot(this, V, marshaledName);
         }
 
-        public LLVMValueRef BuildNSWAdd(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildNSWAdd(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildNSWAdd(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildNSWAdd(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildNSWAdd(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildNSWMul(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildNSWMul(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildNSWMul(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildNSWMul(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildNSWMul(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildNSWNeg(LLVMValueRef V, string Name = "")
+        public LLVMValueRef BuildNSWNeg(LLVMValueRef V, string Name = "") => BuildNSWNeg(V, Name.AsSpan());
+
+        public LLVMValueRef BuildNSWNeg(LLVMValueRef V, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildNSWNeg(this, V, marshaledName);
         }
 
-        public LLVMValueRef BuildNSWSub(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildNSWSub(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildNSWSub(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildNSWSub(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildNSWSub(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildNUWAdd(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildNUWAdd(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildNUWAdd(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildNUWAdd(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildNUWAdd(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildNUWMul(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildNUWMul(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildNUWMul(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildNUWMul(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildNUWMul(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildNUWNeg(LLVMValueRef V, string Name = "")
+        public LLVMValueRef BuildNUWNeg(LLVMValueRef V, string Name = "") => BuildNUWNeg(V, Name.AsSpan());
+
+        public LLVMValueRef BuildNUWNeg(LLVMValueRef V, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildNUWNeg(this, V, marshaledName);
         }
 
-        public LLVMValueRef BuildNUWSub(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildNUWSub(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildNUWSub(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildNUWSub(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildNUWSub(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildOr(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildOr(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildOr(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildOr(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildOr(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildPhi(LLVMTypeRef Ty, string Name = "")
+        public LLVMValueRef BuildPhi(LLVMTypeRef Ty, string Name = "") => BuildPhi(Ty, Name.AsSpan());
+
+        public LLVMValueRef BuildPhi(LLVMTypeRef Ty, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildPhi(this, Ty, marshaledName);
         }
 
-        public LLVMValueRef BuildPointerCast(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildPointerCast(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildPointerCast(Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildPointerCast(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildPointerCast(this, Val, DestTy, marshaledName);
         }
 
-        public LLVMValueRef BuildPtrDiff(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildPtrDiff(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildPtrDiff(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildPtrDiff(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildPtrDiff(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildPtrToInt(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildPtrToInt(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildPtrToInt(Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildPtrToInt(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildPtrToInt(this, Val, DestTy, marshaledName);
@@ -433,49 +557,65 @@ namespace LLVMSharp.Interop
 
         public LLVMValueRef BuildRetVoid() => LLVM.BuildRetVoid(this);
 
-        public LLVMValueRef BuildSDiv(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildSDiv(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildSDiv(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildSDiv(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildSDiv(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildSelect(LLVMValueRef If, LLVMValueRef Then, LLVMValueRef Else, string Name = "")
+        public LLVMValueRef BuildSelect(LLVMValueRef If, LLVMValueRef Then, LLVMValueRef Else, string Name = "") => BuildSelect(If, Then, Else, Name.AsSpan());
+
+        public LLVMValueRef BuildSelect(LLVMValueRef If, LLVMValueRef Then, LLVMValueRef Else, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildSelect(this, If, Then, Else, marshaledName);
         }
 
-        public LLVMValueRef BuildSExt(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildSExt(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildSExt(Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildSExt(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildSExt(this, Val, DestTy, marshaledName);
         }
 
-        public LLVMValueRef BuildSExtOrBitCast(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildSExtOrBitCast(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildSExtOrBitCast(Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildSExtOrBitCast(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildSExtOrBitCast(this, Val, DestTy, marshaledName);
         }
 
-        public LLVMValueRef BuildShl(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildShl(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildShl(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildShl(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildShl(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildShuffleVector(LLVMValueRef V1, LLVMValueRef V2, LLVMValueRef Mask, string Name = "")
+        public LLVMValueRef BuildShuffleVector(LLVMValueRef V1, LLVMValueRef V2, LLVMValueRef Mask, string Name = "") => BuildShuffleVector(V1, V2, Mask, Name.AsSpan());
+
+        public LLVMValueRef BuildShuffleVector(LLVMValueRef V1, LLVMValueRef V2, LLVMValueRef Mask, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildShuffleVector(this, V1, V2, Mask, marshaledName);
         }
 
-        public LLVMValueRef BuildSIToFP(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildSIToFP(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildSIToFP(Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildSIToFP(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildSIToFP(this, Val, DestTy, marshaledName);
         }
 
-        public LLVMValueRef BuildSRem(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildSRem(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildSRem(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildSRem(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildSRem(this, LHS, RHS, marshaledName);
@@ -483,13 +623,17 @@ namespace LLVMSharp.Interop
 
         public LLVMValueRef BuildStore(LLVMValueRef Val, LLVMValueRef Ptr) => LLVM.BuildStore(this, Val, Ptr);
 
-        public LLVMValueRef BuildStructGEP(LLVMValueRef Pointer, uint Idx, string Name = "")
+        public LLVMValueRef BuildStructGEP(LLVMValueRef Pointer, uint Idx, string Name = "") => BuildStructGEP(Pointer, Idx, Name.AsSpan());
+
+        public LLVMValueRef BuildStructGEP(LLVMValueRef Pointer, uint Idx, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildStructGEP(this, Pointer, Idx, marshaledName);
         }
 
-        public LLVMValueRef BuildSub(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildSub(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildSub(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildSub(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildSub(this, LHS, RHS, marshaledName);
@@ -497,25 +641,33 @@ namespace LLVMSharp.Interop
 
         public LLVMValueRef BuildSwitch(LLVMValueRef V, LLVMBasicBlockRef Else, uint NumCases) => LLVM.BuildSwitch(this, V, Else, NumCases);
 
-        public LLVMValueRef BuildTrunc(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildTrunc(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildTrunc(Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildTrunc(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildTrunc(this, Val, DestTy, marshaledName);
         }
 
-        public LLVMValueRef BuildTruncOrBitCast(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildTruncOrBitCast(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildTruncOrBitCast(Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildTruncOrBitCast(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildTruncOrBitCast(this, Val, DestTy, marshaledName);
         }
 
-        public LLVMValueRef BuildUDiv(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildUDiv(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildUDiv(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildUDiv(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildUDiv(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildUIToFP(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildUIToFP(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildUIToFP(Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildUIToFP(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildUIToFP(this, Val, DestTy, marshaledName);
@@ -523,31 +675,41 @@ namespace LLVMSharp.Interop
 
         public LLVMValueRef BuildUnreachable() => LLVM.BuildUnreachable(this);
 
-        public LLVMValueRef BuildURem(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildURem(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildURem(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildURem(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildURem(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildVAArg(LLVMValueRef List, LLVMTypeRef Ty, string Name = "")
+        public LLVMValueRef BuildVAArg(LLVMValueRef List, LLVMTypeRef Ty, string Name = "") => BuildVAArg(List, Ty, Name.AsSpan());
+
+        public LLVMValueRef BuildVAArg(LLVMValueRef List, LLVMTypeRef Ty, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildVAArg(this, List, Ty, marshaledName);
         }
 
-        public LLVMValueRef BuildXor(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "")
+        public LLVMValueRef BuildXor(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildXor(LHS, RHS, Name.AsSpan());
+
+        public LLVMValueRef BuildXor(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildXor(this, LHS, RHS, marshaledName);
         }
 
-        public LLVMValueRef BuildZExt(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildZExt(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildZExt(Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildZExt(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildZExt(this, Val, DestTy, marshaledName);
         }
 
-        public LLVMValueRef BuildZExtOrBitCast(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "")
+        public LLVMValueRef BuildZExtOrBitCast(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildZExtOrBitCast(Val, DestTy, Name.AsSpan());
+
+        public LLVMValueRef BuildZExtOrBitCast(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildZExtOrBitCast(this, Val, DestTy, marshaledName);
@@ -571,7 +733,9 @@ namespace LLVMSharp.Interop
 
         public void Insert(LLVMValueRef Instr) => LLVM.InsertIntoBuilder(this, Instr);
 
-        public void InsertWithName(LLVMValueRef Instr, string Name = "")
+        public void InsertWithName(LLVMValueRef Instr, string Name = "") => InsertWithName(Instr, Name.AsSpan());
+
+        public void InsertWithName(LLVMValueRef Instr, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             LLVM.InsertIntoBuilderWithName(this, Instr, marshaledName);

--- a/sources/LLVMSharp/Interop.Extensions/LLVMContextRef.cs
+++ b/sources/LLVMSharp/Interop.Extensions/LLVMContextRef.cs
@@ -60,35 +60,38 @@ namespace LLVMSharp.Interop
 
         public static LLVMContextRef Create() => LLVM.ContextCreate();
 
-        public LLVMBasicBlockRef AppendBasicBlock(LLVMValueRef Fn, string Name)
+        public LLVMBasicBlockRef AppendBasicBlock(LLVMValueRef Fn, string Name) => AppendBasicBlock(Fn, Name.AsSpan());
+
+        public LLVMBasicBlockRef AppendBasicBlock(LLVMValueRef Fn, ReadOnlySpan<char> Name)
         {
-            using var marshaledName = new MarshaledString(Name);
-            return LLVM.AppendBasicBlockInContext(this, Fn, marshaledName);
+            return LLVMBasicBlockRef.AppendInContext(this, Fn, Name);
         }
 
-        public LLVMBuilderRef CreateBuilder()
+        public LLVMBasicBlockRef CreateBasicBlock(string Name) => CreateBasicBlock(Name.AsSpan());
+
+        public LLVMBasicBlockRef CreateBasicBlock(ReadOnlySpan<char> Name)
         {
-            return LLVM.CreateBuilderInContext(this);
+            return LLVMBasicBlockRef.CreateInContext(this, Name);
         }
+
+        public LLVMBuilderRef CreateBuilder() => LLVMBuilderRef.Create(this);
 
         public LLVMMetadataRef CreateDebugLocation(uint Line, uint Column, LLVMMetadataRef Scope, LLVMMetadataRef InlinedAt)
         {
             return LLVM.DIBuilderCreateDebugLocation(this, Line, Column, Scope, InlinedAt);
         }
 
-        public LLVMModuleRef CreateModuleWithName(string ModuleID)
+        public LLVMModuleRef CreateModuleWithName(string ModuleID) => CreateModuleWithName(ModuleID.AsSpan());
+
+        public LLVMModuleRef CreateModuleWithName(ReadOnlySpan<char> ModuleID)
         {
             using var marshaledModuleID = new MarshaledString(ModuleID);
             return LLVM.ModuleCreateWithNameInContext(marshaledModuleID, this);
         }
 
-        public LLVMValueRef MetadataAsValue(LLVMMetadataRef MD)
-        {
-            return LLVM.MetadataAsValue(this, MD);
-        }
+        public LLVMTypeRef CreateNamedStruct(string Name) => CreateNamedStruct(Name.AsSpan());
 
-
-        public LLVMTypeRef CreateNamedStruct(string Name)
+        public LLVMTypeRef CreateNamedStruct(ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.StructCreateNamed(this, marshaledName);
@@ -117,17 +120,21 @@ namespace LLVMSharp.Interop
             return M;
         }
 
-        public LLVMValueRef GetConstString(string Str, uint Length, bool DontNullTerminate)
+        public LLVMValueRef GetConstString(string Str, bool DontNullTerminate) => GetConstString(Str.AsSpan(), DontNullTerminate);
+
+        public LLVMValueRef GetConstString(ReadOnlySpan<char> Str, bool DontNullTerminate)
         {
             using var marshaledStr = new MarshaledString(Str);
-            return LLVM.ConstStringInContext(this, marshaledStr, Length, DontNullTerminate ? 1 : 0);
+            return LLVM.ConstStringInContext(this, marshaledStr, (uint)marshaledStr.Length, DontNullTerminate ? 1 : 0);
         }
 
-        public LLVMValueRef GetConstStruct(LLVMValueRef[] ConstantVals, bool Packed)
+        public LLVMValueRef GetConstStruct(LLVMValueRef[] ConstantVals, bool Packed) => GetConstStruct(ConstantVals.AsSpan(), Packed);
+
+        public LLVMValueRef GetConstStruct(ReadOnlySpan<LLVMValueRef> ConstantVals, bool Packed)
         {
             fixed (LLVMValueRef* pConstantVals = ConstantVals)
             {
-                return LLVM.ConstStructInContext(this, (LLVMOpaqueValue**)pConstantVals, (uint)ConstantVals?.Length, Packed ? 1 : 0);
+                return LLVM.ConstStructInContext(this, (LLVMOpaqueValue**)pConstantVals, (uint)ConstantVals.Length, Packed ? 1 : 0);
             }
         }
 
@@ -139,41 +146,52 @@ namespace LLVMSharp.Interop
 
         public LLVMTypeRef GetIntType(uint NumBits) => LLVM.IntTypeInContext(this, NumBits);
 
-        public uint GetMDKindID(string Name, uint SLen)
+        public uint GetMDKindID(string Name, uint SLen) => GetMDKindID(Name.AsSpan(0, (int)SLen));
+
+        public uint GetMDKindID(ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
-            return LLVM.GetMDKindIDInContext(this, marshaledName, SLen);
+            return LLVM.GetMDKindIDInContext(this, marshaledName, (uint)marshaledName.Length);
         }
 
-        public LLVMValueRef GetMDNode(LLVMValueRef[] Vals)
+        public LLVMValueRef GetMDNode(LLVMValueRef[] Vals) => GetMDNode(Vals.AsSpan());
+
+        public LLVMValueRef GetMDNode(ReadOnlySpan<LLVMValueRef> Vals)
         {
             fixed (LLVMValueRef* pVals = Vals)
             {
-                return LLVM.MDNodeInContext(this, (LLVMOpaqueValue**)pVals, (uint)Vals?.Length);
+                return LLVM.MDNodeInContext(this, (LLVMOpaqueValue**)pVals, (uint)Vals.Length);
             }
         }
 
-        public LLVMValueRef GetMDString(string Str, uint SLen)
+        public LLVMValueRef GetMDString(string Str, uint SLen) => GetMDString(Str.AsSpan(0, (int)SLen));
+
+        public LLVMValueRef GetMDString(ReadOnlySpan<char> Str)
         {
             using var marshaledStr = new MarshaledString(Str);
-            return LLVM.MDStringInContext(this, marshaledStr, SLen);
+            return LLVM.MDStringInContext(this, marshaledStr, (uint)marshaledStr.Length);
         }
 
-        public LLVMTypeRef GetStructType(LLVMTypeRef[] ElementTypes, bool Packed)
+        public LLVMTypeRef GetStructType(LLVMTypeRef[] ElementTypes, bool Packed) => GetStructType(ElementTypes.AsSpan(), Packed);
+
+        public LLVMTypeRef GetStructType(ReadOnlySpan<LLVMTypeRef> ElementTypes, bool Packed)
         {
             fixed (LLVMTypeRef* pElementTypes = ElementTypes)
             {
-                return LLVM.StructTypeInContext(this, (LLVMOpaqueType**)pElementTypes, (uint)ElementTypes?.Length, Packed ? 1 : 0);
+                return LLVM.StructTypeInContext(this, (LLVMOpaqueType**)pElementTypes, (uint)ElementTypes.Length, Packed ? 1 : 0);
             }
         }
 
         public LLVMBasicBlockRef InsertBasicBlock(LLVMBasicBlockRef BB, string Name)
         {
-            using var marshaledName = new MarshaledString(Name);
-            return LLVM.InsertBasicBlockInContext(this, BB, marshaledName);
+            return LLVMBasicBlockRef.InsertInContext(this, BB, Name);
         }
 
-        
+        public LLVMValueRef MetadataAsValue(LLVMMetadataRef MD)
+        {
+            return LLVM.MetadataAsValue(this, MD);
+        }
+
         public LLVMModuleRef ParseBitcode(LLVMMemoryBufferRef MemBuf)
         {
             if (!TryParseBitcode(MemBuf, out LLVMModuleRef M, out string Message))

--- a/sources/LLVMSharp/Interop.Extensions/LLVMDIBuilderRef.cs
+++ b/sources/LLVMSharp/Interop.Extensions/LLVMDIBuilderRef.cs
@@ -14,7 +14,10 @@ namespace LLVMSharp.Interop
         public IntPtr Handle;
 
         public LLVMMetadataRef CreateCompileUnit(LLVMDWARFSourceLanguage SourceLanguage, LLVMMetadataRef FileMetadata, string Producer, int IsOptimized, string Flags, uint RuntimeVersion,
-            string SplitName, LLVMDWARFEmissionKind DwarfEmissionKind, uint DWOld, int SplitDebugInlining, int DebugInfoForProfiling)
+            string SplitName, LLVMDWARFEmissionKind DwarfEmissionKind, uint DWOld, int SplitDebugInlining, int DebugInfoForProfiling) => CreateCompileUnit(SourceLanguage, FileMetadata, Producer.AsSpan(), IsOptimized, Flags.AsSpan(), RuntimeVersion, SplitName.AsSpan(), DwarfEmissionKind, DWOld, SplitDebugInlining, DebugInfoForProfiling);
+
+        public LLVMMetadataRef CreateCompileUnit(LLVMDWARFSourceLanguage SourceLanguage, LLVMMetadataRef FileMetadata, ReadOnlySpan<char> Producer, int IsOptimized, ReadOnlySpan<char> Flags, uint RuntimeVersion,
+            ReadOnlySpan<char> SplitName, LLVMDWARFEmissionKind DwarfEmissionKind, uint DWOld, int SplitDebugInlining, int DebugInfoForProfiling)
         {
             using var marshaledProducer= new MarshaledString(Producer);
             using var marshaledFlags = new MarshaledString(Flags);
@@ -24,7 +27,9 @@ namespace LLVMSharp.Interop
                 RuntimeVersion, marshaledSplitNameFlags, (UIntPtr)marshaledSplitNameFlags.Length, DwarfEmissionKind, DWOld, SplitDebugInlining, DebugInfoForProfiling);
         }
 
-        public LLVMMetadataRef CreateFile(string FullPath, string Directory)
+        public LLVMMetadataRef CreateFile(string FullPath, string Directory) => CreateFile(FullPath.AsSpan(), Directory.AsSpan());
+
+        public LLVMMetadataRef CreateFile(ReadOnlySpan<char> FullPath, ReadOnlySpan<char> Directory)
         {
             using var marshaledFullPath = new MarshaledString(FullPath);
             using var marshaledDirectory = new MarshaledString(Directory);
@@ -32,6 +37,9 @@ namespace LLVMSharp.Interop
         }
 
         public LLVMMetadataRef CreateFunction(LLVMMetadataRef Scope, string Name, string LinkageName, LLVMMetadataRef File, uint LineNo, LLVMMetadataRef Type, int IsLocalToUnit, int IsDefinition,
+            uint ScopeLine, LLVMDIFlags Flags, int IsOptimized) => CreateFunction(Scope, Name.AsSpan(), LinkageName.AsSpan(), File, LineNo, Type, IsLocalToUnit, IsDefinition, ScopeLine, Flags, IsOptimized);
+
+        public LLVMMetadataRef CreateFunction(LLVMMetadataRef Scope, ReadOnlySpan<char> Name, ReadOnlySpan<char> LinkageName, LLVMMetadataRef File, uint LineNo, LLVMMetadataRef Type, int IsLocalToUnit, int IsDefinition,
             uint ScopeLine, LLVMDIFlags Flags, int IsOptimized)
         {
             using var marshaledName = new MarshaledString(Name);
@@ -43,7 +51,9 @@ namespace LLVMSharp.Interop
                 LineNo, Type, IsLocalToUnit, IsDefinition, ScopeLine, Flags, IsOptimized);
         }
 
-        public LLVMMetadataRef CreateMacro(LLVMMetadataRef ParentMacroFile, uint Line, LLVMDWARFMacinfoRecordType RecordType, string Name, string Value)
+        public LLVMMetadataRef CreateMacro(LLVMMetadataRef ParentMacroFile, uint Line, LLVMDWARFMacinfoRecordType RecordType, string Name, string Value) => CreateMacro(ParentMacroFile, Line, RecordType, Name.AsSpan(), Value.AsSpan());
+
+        public LLVMMetadataRef CreateMacro(LLVMMetadataRef ParentMacroFile, uint Line, LLVMDWARFMacinfoRecordType RecordType, ReadOnlySpan<char> Name, ReadOnlySpan<char> Value)
         {
             using var marshaledName = new MarshaledString(Name);
             using var marshaledValue = new MarshaledString(Value);
@@ -53,7 +63,9 @@ namespace LLVMSharp.Interop
             return LLVM.DIBuilderCreateMacro(this, ParentMacroFile, Line, RecordType, marshaledName, (UIntPtr)nameLength, marshaledValue, (UIntPtr)valueLength);
         }
 
-        public LLVMMetadataRef CreateModule(LLVMMetadataRef ParentScope, string Name, string ConfigMacros, string IncludePath, string SysRoot)
+        public LLVMMetadataRef CreateModule(LLVMMetadataRef ParentScope, string Name, string ConfigMacros, string IncludePath, string SysRoot) => CreateModule(ParentScope, Name.AsSpan(), ConfigMacros.AsSpan(), IncludePath.AsSpan(), SysRoot.AsSpan());
+
+        public LLVMMetadataRef CreateModule(LLVMMetadataRef ParentScope, ReadOnlySpan<char> Name, ReadOnlySpan<char> ConfigMacros, ReadOnlySpan<char> IncludePath, ReadOnlySpan<char> SysRoot)
         {
             using var marshaledName = new MarshaledString(Name);
             using var marshaledConfigMacros = new MarshaledString(ConfigMacros);
@@ -67,6 +79,8 @@ namespace LLVMSharp.Interop
             return LLVM.DIBuilderCreateModule(this, ParentScope, marshaledName, (UIntPtr)nameLength, marshaledConfigMacros, (UIntPtr)configMacrosLength, marshaledIncludePath, (UIntPtr)includePathLength, marshaledSysRoot, (UIntPtr)sysRootLength);
         }
 
+        public LLVMMetadataRef CreateSubroutineType(LLVMMetadataRef File, LLVMMetadataRef[] ParameterTypes, LLVMDIFlags Flags) => CreateSubroutineType(File, ParameterTypes.AsSpan(), Flags);
+
         public LLVMMetadataRef CreateSubroutineType(LLVMMetadataRef File, ReadOnlySpan<LLVMMetadataRef> ParameterTypes, LLVMDIFlags Flags)
         {
             fixed (LLVMMetadataRef* pParameterTypes = ParameterTypes)
@@ -77,7 +91,9 @@ namespace LLVMSharp.Interop
 
         public LLVMMetadataRef CreateTempMacroFile(LLVMMetadataRef ParentMacroFile, uint Line, LLVMMetadataRef File) => LLVM.DIBuilderCreateTempMacroFile(this, ParentMacroFile, Line, File);
 
-        public LLVMMetadataRef CreateTypedef(LLVMMetadataRef Type, string Name, LLVMMetadataRef File, uint LineNo, LLVMMetadataRef Scope, uint AlignInBits)
+        public LLVMMetadataRef CreateTypedef(LLVMMetadataRef Type, string Name, LLVMMetadataRef File, uint LineNo, LLVMMetadataRef Scope, uint AlignInBits) => CreateTypedef(Type, Name.AsSpan(), File, LineNo, Scope, AlignInBits);
+
+        public LLVMMetadataRef CreateTypedef(LLVMMetadataRef Type, ReadOnlySpan<char> Name, LLVMMetadataRef File, uint LineNo, LLVMMetadataRef Scope, uint AlignInBits)
         {
             using var marshaledName = new MarshaledString(Name);
             var nameLength = (uint)marshaledName.Length;

--- a/sources/LLVMSharp/Interop.Extensions/LLVMExecutionEngineRef.cs
+++ b/sources/LLVMSharp/Interop.Extensions/LLVMExecutionEngineRef.cs
@@ -49,7 +49,9 @@ namespace LLVMSharp.Interop
 
         public bool Equals(LLVMExecutionEngineRef other) => Handle == other.Handle;
 
-        public LLVMValueRef FindFunction(string Name)
+        public LLVMValueRef FindFunction(string Name) => FindFunction(Name.AsSpan());
+
+        public LLVMValueRef FindFunction(ReadOnlySpan<char> Name)
         {
             if (!TryFindFunction(Name, out var Fn))
             {
@@ -61,13 +63,17 @@ namespace LLVMSharp.Interop
 
         public void FreeMachineCodeForFunction(LLVMValueRef F) => LLVM.FreeMachineCodeForFunction(this, F);
 
-        public ulong GetFunctionAddress(string Name)
+        public ulong GetFunctionAddress(string Name) => GetFunctionAddress(Name.AsSpan());
+
+        public ulong GetFunctionAddress(ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.GetFunctionAddress(this, marshaledName);
         }
 
-        public ulong GetGlobalValueAddress(string Name)
+        public ulong GetGlobalValueAddress(string Name) => GetGlobalValueAddress(Name.AsSpan()); 
+
+        public ulong GetGlobalValueAddress(ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.GetGlobalValueAddress(this, marshaledName);
@@ -93,15 +99,19 @@ namespace LLVMSharp.Interop
             return Mod;
         }
 
-        public LLVMGenericValueRef RunFunction(LLVMValueRef F, LLVMGenericValueRef[] Args)
+        public LLVMGenericValueRef RunFunction(LLVMValueRef F, LLVMGenericValueRef[] Args) => RunFunction(F, Args.AsSpan());
+
+        public LLVMGenericValueRef RunFunction(LLVMValueRef F, ReadOnlySpan<LLVMGenericValueRef> Args)
         {
             fixed (LLVMGenericValueRef* pArgs = Args)
             {
-                return LLVM.RunFunction(this, F, (uint)Args?.Length, (LLVMOpaqueGenericValue**)pArgs);
+                return LLVM.RunFunction(this, F, (uint)Args.Length, (LLVMOpaqueGenericValue**)pArgs);
             }
         }
 
-        public int RunFunctionAsMain(LLVMValueRef F, uint ArgC, string[] ArgV, string[] EnvP)
+        public int RunFunctionAsMain(LLVMValueRef F, uint ArgC, string[] ArgV, string[] EnvP) => RunFunctionAsMain(F, ArgC, ArgV.AsSpan(), EnvP.AsSpan());
+
+        public int RunFunctionAsMain(LLVMValueRef F, uint ArgC, ReadOnlySpan<string> ArgV, ReadOnlySpan<string> EnvP)
         {
             using var marshaledArgV = new MarshaledStringArray(ArgV);
             using var marshaledEnvP = new MarshaledStringArray(EnvP);
@@ -121,7 +131,9 @@ namespace LLVMSharp.Interop
 
         public IntPtr RecompileAndRelinkFunction(LLVMValueRef Fn) => (IntPtr)LLVM.RecompileAndRelinkFunction(this, Fn);
 
-        public bool TryFindFunction(string Name, out LLVMValueRef OutFn)
+        public bool TryFindFunction(string Name, out LLVMValueRef OutFn) => TryFindFunction(Name.AsSpan(), out OutFn);
+
+        public bool TryFindFunction(ReadOnlySpan<char> Name, out LLVMValueRef OutFn)
         {
             fixed (LLVMValueRef* pOutFn = &OutFn)
             {

--- a/sources/LLVMSharp/Interop.Extensions/LLVMModuleRef.cs
+++ b/sources/LLVMSharp/Interop.Extensions/LLVMModuleRef.cs
@@ -48,7 +48,7 @@ namespace LLVMSharp.Interop
 
             set
             {
-                using var marshaledDataLayoutStr = new MarshaledString(value);
+                using var marshaledDataLayoutStr = new MarshaledString(value.AsSpan());
                 LLVM.SetDataLayout(this, marshaledDataLayoutStr);
             }
         }
@@ -83,7 +83,7 @@ namespace LLVMSharp.Interop
 
             set
             {
-                using var marshaledTriple = new MarshaledString(value);
+                using var marshaledTriple = new MarshaledString(value.AsSpan());
                 LLVM.SetTarget(this, marshaledTriple);
             }
         }
@@ -92,37 +92,49 @@ namespace LLVMSharp.Interop
 
         public static bool operator !=(LLVMModuleRef left, LLVMModuleRef right) => !(left == right);
 
-        public static LLVMModuleRef CreateWithName(string ModuleID)
+        public static LLVMModuleRef CreateWithName(string ModuleID) => CreateWithName(ModuleID.AsSpan());
+
+        public static LLVMModuleRef CreateWithName(ReadOnlySpan<char> ModuleID)
         {
             using var marshaledModuleID = new MarshaledString(ModuleID);
             return LLVM.ModuleCreateWithName(marshaledModuleID);
         }
 
-        public LLVMValueRef AddAlias(LLVMTypeRef Ty, LLVMValueRef Aliasee, string Name)
+        public LLVMValueRef AddAlias(LLVMTypeRef Ty, LLVMValueRef Aliasee, string Name) => AddAlias(Ty, Aliasee, Name.AsSpan());
+
+        public LLVMValueRef AddAlias(LLVMTypeRef Ty, LLVMValueRef Aliasee, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.AddAlias(this, Ty, Aliasee, marshaledName);
         }
 
-        public LLVMValueRef AddFunction(string Name, LLVMTypeRef FunctionTy)
+        public LLVMValueRef AddFunction(string Name, LLVMTypeRef FunctionTy) => AddFunction(Name.AsSpan(), FunctionTy);
+
+        public LLVMValueRef AddFunction(ReadOnlySpan<char> Name, LLVMTypeRef FunctionTy)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.AddFunction(this, marshaledName, FunctionTy);
         }
 
-        public LLVMValueRef AddGlobal(LLVMTypeRef Ty, string Name)
+        public LLVMValueRef AddGlobal(LLVMTypeRef Ty, string Name) => AddGlobal(Ty, Name.AsSpan());
+
+        public LLVMValueRef AddGlobal(LLVMTypeRef Ty, ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.AddGlobal(this, Ty, marshaledName);
         }
 
-        public LLVMValueRef AddGlobalInAddressSpace(LLVMTypeRef Ty, string Name, uint AddressSpace)
+        public LLVMValueRef AddGlobalInAddressSpace(LLVMTypeRef Ty, string Name, uint AddressSpace) => AddGlobalInAddressSpace(Ty, Name.AsSpan(), AddressSpace);
+
+        public LLVMValueRef AddGlobalInAddressSpace(LLVMTypeRef Ty, ReadOnlySpan<char> Name, uint AddressSpace)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.AddGlobalInAddressSpace(this, Ty, marshaledName, AddressSpace);
         }
 
-        public void AddNamedMetadataOperand(string Name, LLVMValueRef Val)
+        public void AddNamedMetadataOperand(string Name, LLVMValueRef Val) => AddNamedMetadataOperand(Name.AsSpan(), Val);
+
+        public void AddNamedMetadataOperand(ReadOnlySpan<char> Name, LLVMValueRef Val)
         {
             using var marshaledName = new MarshaledString(Name);
             LLVM.AddNamedMetadataOperand(this, marshaledName, Val);
@@ -179,7 +191,9 @@ namespace LLVMSharp.Interop
 
         public LLVMModuleProviderRef CreateModuleProvider() => LLVM.CreateModuleProviderForExistingModule(this);
 
-        public void AddNamedMetadataOperand(string Name, LLVMMetadataRef CompileUnitMetadata)
+        public void AddNamedMetadataOperand(string Name, LLVMMetadataRef CompileUnitMetadata) => AddNamedMetadataOperand(Name.AsSpan(), CompileUnitMetadata);
+
+        public void AddNamedMetadataOperand(ReadOnlySpan<char> Name, LLVMMetadataRef CompileUnitMetadata)
         {
             using var marshaledName = new MarshaledString(Name);
             LLVM.AddNamedMetadataOperand(this, marshaledName, LLVM.MetadataAsValue(Context, CompileUnitMetadata));
@@ -200,7 +214,9 @@ namespace LLVMSharp.Interop
 
         public bool Equals(LLVMModuleRef other) => Handle == other.Handle;
 
-        public LLVMValueRef GetNamedFunction(string Name)
+        public LLVMValueRef GetNamedFunction(string Name) => GetNamedFunction(Name.AsSpan());
+
+        public LLVMValueRef GetNamedFunction(ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.GetNamedFunction(this, marshaledName);
@@ -208,13 +224,17 @@ namespace LLVMSharp.Interop
 
         public override int GetHashCode() => Handle.GetHashCode();
 
-        public LLVMValueRef GetNamedGlobal(string Name)
+        public LLVMValueRef GetNamedGlobal(string Name) => GetNamedGlobal(Name.AsSpan());
+
+        public LLVMValueRef GetNamedGlobal(ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.GetNamedGlobal(this, marshaledName);
         }
 
-        public LLVMValueRef[] GetNamedMetadataOperands(string Name)
+        public LLVMValueRef[] GetNamedMetadataOperands(string Name) => GetNamedMetadataOperands(Name.AsSpan());
+
+        public LLVMValueRef[] GetNamedMetadataOperands(ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             var Dest = new LLVMValueRef[LLVM.GetNamedMetadataNumOperands(this, marshaledName)];
@@ -227,19 +247,25 @@ namespace LLVMSharp.Interop
             return Dest;
         }
 
-        public uint GetNamedMetadataOperandsCount(string Name)
+        public uint GetNamedMetadataOperandsCount(string Name) => GetNamedMetadataOperandsCount(Name.AsSpan());
+
+        public uint GetNamedMetadataOperandsCount(ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.GetNamedMetadataNumOperands(this, marshaledName);
         }
 
-        public LLVMTypeRef GetTypeByName(string Name)
+        public LLVMTypeRef GetTypeByName(string Name) => GetTypeByName(Name.AsSpan());
+
+        public LLVMTypeRef GetTypeByName(ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.GetTypeByName(this, marshaledName);
         }
 
-        public void PrintToFile(string Filename)
+        public void PrintToFile(string Filename) => PrintToFile(Filename.AsSpan());
+
+        public void PrintToFile(ReadOnlySpan<char> Filename)
         {
             if (!TryPrintToFile(Filename, out string ErrorMessage))
             {
@@ -262,7 +288,9 @@ namespace LLVMSharp.Interop
             return result;
         }
 
-        public void SetModuleInlineAsm(string Asm)
+        public void SetModuleInlineAsm(string Asm) => SetModuleInlineAsm(Asm.AsSpan());
+
+        public void SetModuleInlineAsm(ReadOnlySpan<char> Asm)
         {
             using var marshaledAsm = new MarshaledString(Asm);
             LLVM.SetModuleInlineAsm(this, marshaledAsm);
@@ -340,7 +368,9 @@ namespace LLVMSharp.Interop
             }
         }
 
-        public bool TryPrintToFile(string Filename, out string ErrorMessage)
+        public bool TryPrintToFile(string Filename, out string ErrorMessage) => TryPrintToFile(Filename.AsSpan(), out ErrorMessage);
+
+        public bool TryPrintToFile(ReadOnlySpan<char> Filename, out string ErrorMessage)
         {
             using var marshaledFilename = new MarshaledString(Filename);
 
@@ -394,7 +424,9 @@ namespace LLVMSharp.Interop
             }
         }
 
-        public int WriteBitcodeToFile(string Path)
+        public int WriteBitcodeToFile(string Path) => WriteBitcodeToFile(Path.AsSpan());
+
+        public int WriteBitcodeToFile(ReadOnlySpan<char> Path)
         {
             using var marshaledPath = new MarshaledString(Path);
             return LLVM.WriteBitcodeToFile(this, marshaledPath);

--- a/sources/LLVMSharp/Interop.Extensions/LLVMTargetMachineRef.cs
+++ b/sources/LLVMSharp/Interop.Extensions/LLVMTargetMachineRef.cs
@@ -41,7 +41,9 @@ namespace LLVMSharp.Interop
             return span.Slice(0, span.IndexOf((byte)'\0')).AsString();
         }
 
-        public void EmitToFile(LLVMModuleRef module, string fileName, LLVMCodeGenFileType codegen)
+        public void EmitToFile(LLVMModuleRef module, string fileName, LLVMCodeGenFileType codegen) => EmitToFile(module, fileName.AsSpan(), codegen);
+
+        public void EmitToFile(LLVMModuleRef module, ReadOnlySpan<char> fileName, LLVMCodeGenFileType codegen)
         {
             if (!TryEmitToFile(module, fileName, codegen, out string Error))
             {
@@ -55,7 +57,9 @@ namespace LLVMSharp.Interop
 
         public override int GetHashCode() => Handle.GetHashCode();
 
-        public bool TryEmitToFile(LLVMModuleRef module, string fileName, LLVMCodeGenFileType codegen, out string message)
+        public bool TryEmitToFile(LLVMModuleRef module, string fileName, LLVMCodeGenFileType codegen, out string message) => TryEmitToFile(module, fileName.AsSpan(), codegen, out message);
+
+        public bool TryEmitToFile(LLVMModuleRef module, ReadOnlySpan<char> fileName, LLVMCodeGenFileType codegen, out string message)
         {
             using var marshaledFileName = new MarshaledString(fileName);
 

--- a/sources/LLVMSharp/Interop.Extensions/LLVMTargetRef.cs
+++ b/sources/LLVMSharp/Interop.Extensions/LLVMTargetRef.cs
@@ -89,7 +89,9 @@ namespace LLVMSharp.Interop
 
         public LLVMTargetRef GetNext() => LLVM.GetNextTarget(this);
 
-        public LLVMTargetMachineRef CreateTargetMachine(string triple, string cpu, string features, LLVMCodeGenOptLevel level, LLVMRelocMode reloc, LLVMCodeModel codeModel)
+        public LLVMTargetMachineRef CreateTargetMachine(string triple, string cpu, string features, LLVMCodeGenOptLevel level, LLVMRelocMode reloc, LLVMCodeModel codeModel) => CreateTargetMachine(triple.AsSpan(), cpu.AsSpan(), features.AsSpan(), level, reloc, codeModel);
+
+        public LLVMTargetMachineRef CreateTargetMachine(ReadOnlySpan<char> triple, ReadOnlySpan<char> cpu, ReadOnlySpan<char> features, LLVMCodeGenOptLevel level, LLVMRelocMode reloc, LLVMCodeModel codeModel)
         {
             using var marshaledTriple = new MarshaledString(triple);
             using var marshaledCPU = new MarshaledString(cpu);

--- a/sources/LLVMSharp/Interop.Extensions/LLVMValueRef.cs
+++ b/sources/LLVMSharp/Interop.Extensions/LLVMValueRef.cs
@@ -22,18 +22,16 @@ namespace LLVMSharp.Interop
         {
             return (LLVMOpaqueValue*)value.Handle;
         }
-
+ 
         public uint Alignment
         {
-            get => (Handle != IntPtr.Zero) ? LLVM.GetAlignment(this) : default;
+            get => ((IsAGlobalValue != null) || (IsAAllocaInst != null) || (IsALoadInst != null) || (IsAStoreInst != null)) ? LLVM.GetAlignment(this) : default;
             set => LLVM.SetAlignment(this, value);
         }
 
-        public LLVMBasicBlockRef AsBasicBlock => (Handle != IntPtr.Zero) ? LLVM.ValueAsBasicBlock(this) : default;
-
         public LLVMAtomicRMWBinOp AtomicRMWBinOp
         {
-            get => (Handle != IntPtr.Zero) ? LLVM.GetAtomicRMWBinOp(this) : default;
+            get => (IsAAtomicRMWInst != null) ? LLVM.GetAtomicRMWBinOp(this) : default;
             set => LLVM.SetAtomicRMWBinOp(this, value);
         }
 
@@ -41,7 +39,7 @@ namespace LLVMSharp.Interop
         {
             get
             {
-                if (Handle == IntPtr.Zero)
+                if (IsAFunction == null)
                 {
                     return Array.Empty<LLVMBasicBlockRef>();
                 }
@@ -57,39 +55,39 @@ namespace LLVMSharp.Interop
             }
         }
 
-        public uint BasicBlocksCount => (Handle != IntPtr.Zero) ? LLVM.CountBasicBlocks(this) : default;
+        public uint BasicBlocksCount => (IsAFunction != null) ? LLVM.CountBasicBlocks(this) : default;
 
         public LLVMValueRef Condition
         {
-            get => (Handle != IntPtr.Zero) ? LLVM.GetCondition(this) : default;
+            get => (IsABranchInst != null) ? LLVM.GetCondition(this) : default;
             set => LLVM.SetCondition(this, value);
         }
 
-        public ulong ConstIntZExt => (Handle != IntPtr.Zero) ? LLVM.ConstIntGetZExtValue(this) : default;
+        public ulong ConstIntZExt => (IsAConstantInt != null) ? LLVM.ConstIntGetZExtValue(this) : default;
 
-        public long ConstIntSExt => (Handle != IntPtr.Zero) ? LLVM.ConstIntGetSExtValue(this) : default;
+        public long ConstIntSExt => (IsAConstantInt != null) ? LLVM.ConstIntGetSExtValue(this) : default;
 
-        public LLVMOpcode ConstOpcode => (Handle != IntPtr.Zero) ? LLVM.GetConstOpcode(this) : default;
+        public LLVMOpcode ConstOpcode => (IsAConstantExpr != null) ? LLVM.GetConstOpcode(this) : default;
 
         public LLVMDLLStorageClass DLLStorageClass
         {
-            get => (Handle != IntPtr.Zero) ? LLVM.GetDLLStorageClass(this) : default;
+            get => (IsAGlobalValue != null) ? LLVM.GetDLLStorageClass(this) : default;
             set => LLVM.SetDLLStorageClass(this, value);
         }
 
-        public LLVMBasicBlockRef EntryBasicBlock => (Handle != IntPtr.Zero) ? LLVM.GetEntryBasicBlock(this) : default;
+        public LLVMBasicBlockRef EntryBasicBlock => (IsAFunction != null) ? LLVM.GetEntryBasicBlock(this) : default;
 
         public LLVMRealPredicate FCmpPredicate => (Handle != IntPtr.Zero) ? LLVM.GetFCmpPredicate(this) : default;
 
-        public LLVMBasicBlockRef FirstBasicBlock => (Handle != IntPtr.Zero) ? LLVM.GetFirstBasicBlock(this) : default;
+        public LLVMBasicBlockRef FirstBasicBlock => (IsAFunction != null) ? LLVM.GetFirstBasicBlock(this) : default;
 
-        public LLVMValueRef FirstParam => (Handle != IntPtr.Zero) ? LLVM.GetFirstParam(this) : default;
+        public LLVMValueRef FirstParam => (IsAFunction != null) ? LLVM.GetFirstParam(this) : default;
 
         public LLVMUseRef FirstUse => (Handle != IntPtr.Zero) ? LLVM.GetFirstUse(this) : default;
 
         public uint FunctionCallConv
         {
-            get => (Handle != IntPtr.Zero) ? LLVM.GetFunctionCallConv(this) : default;
+            get => (IsAFunction != null) ? LLVM.GetFunctionCallConv(this) : default;
             set => LLVM.SetFunctionCallConv(this, value);
         }
 
@@ -97,7 +95,7 @@ namespace LLVMSharp.Interop
         {
             get
             {
-                if (Handle == IntPtr.Zero)
+                if (IsAFunction == null)
                 {
                     return string.Empty;
                 }
@@ -115,34 +113,34 @@ namespace LLVMSharp.Interop
 
             set
             {
-                using var marshaledName = new MarshaledString(value);
+                using var marshaledName = new MarshaledString(value.AsSpan());
                 LLVM.SetGC(this, marshaledName);
             }
         }
 
-        public LLVMModuleRef GlobalParent => (Handle != IntPtr.Zero) ? LLVM.GetGlobalParent(this) : default;
+        public LLVMModuleRef GlobalParent => (IsAGlobalValue != null) ? LLVM.GetGlobalParent(this) : default;
 
-        public bool HasMetadata => (Handle != IntPtr.Zero) ? LLVM.HasMetadata(this) != 0 : default;
+        public bool HasMetadata => (IsAInstruction != null) ? LLVM.HasMetadata(this) != 0 : default;
 
         public bool HasUnnamedAddr
         {
-            get => (Handle != IntPtr.Zero) ? LLVM.HasUnnamedAddr(this) != 0 : default;
+            get => (IsAGlobalValue != null) ? LLVM.HasUnnamedAddr(this) != 0 : default;
             set => LLVM.SetUnnamedAddr(this, value ? 1 : 0);
         }
 
         public LLVMIntPredicate ICmpPredicate => (Handle != IntPtr.Zero) ? LLVM.GetICmpPredicate(this) : default;
 
-        public uint IncomingCount => (Handle != IntPtr.Zero) ? LLVM.CountIncoming(this) : default;
+        public uint IncomingCount => (IsAPHINode != null) ? LLVM.CountIncoming(this) : default;
 
         public LLVMValueRef Initializer
         {
-            get => (Handle != IntPtr.Zero) ? LLVM.GetInitializer(this) : default;
+            get => (IsAGlobalVariable != null) ? LLVM.GetInitializer(this) : default;
             set => LLVM.SetInitializer(this, value);
         }
 
         public uint InstructionCallConv
         {
-            get => (Handle != IntPtr.Zero) ? LLVM.GetInstructionCallConv(this) : default;
+            get => ((IsACallBrInst != null) || (IsACallInst != null) || (IsAInvokeInst != null)) ? LLVM.GetInstructionCallConv(this) : default;
             set => LLVM.SetInstructionCallConv(this, value);
         }
 
@@ -150,197 +148,215 @@ namespace LLVMSharp.Interop
 
         public LLVMOpcode InstructionOpcode => (Handle != IntPtr.Zero) ? LLVM.GetInstructionOpcode(this) : default;
 
-        public LLVMBasicBlockRef InstructionParent => (Handle != IntPtr.Zero) ? LLVM.GetInstructionParent(this) : default;
+        public LLVMBasicBlockRef InstructionParent => (IsAInstruction != null) ? LLVM.GetInstructionParent(this) : default;
 
         public uint IntrinsicID => (Handle != IntPtr.Zero) ? LLVM.GetIntrinsicID(this) : default;
 
-        public LLVMValueRef IsAAddrSpaceCastInst => (Handle != IntPtr.Zero) ? LLVM.IsAAddrSpaceCastInst(this) : default;
+        public LLVMValueRef IsAAddrSpaceCastInst => LLVM.IsAAddrSpaceCastInst(this);
 
-        public LLVMValueRef IsAAllocaInst => (Handle != IntPtr.Zero) ? LLVM.IsAAllocaInst(this) : default;
+        public LLVMValueRef IsAAllocaInst => LLVM.IsAAllocaInst(this);
 
-        public LLVMValueRef IsAArgument => (Handle != IntPtr.Zero) ? LLVM.IsAArgument(this) : default;
+        public LLVMValueRef IsAArgument => LLVM.IsAArgument(this);
 
-        public LLVMValueRef IsAAtomicCmpXchgInst => (Handle != IntPtr.Zero) ? LLVM.IsAAtomicCmpXchgInst(this) : default;
+        public LLVMValueRef IsAAtomicCmpXchgInst => LLVM.IsAAtomicCmpXchgInst(this);
 
-        public LLVMValueRef IsAAtomicRMWInst => (Handle != IntPtr.Zero) ? LLVM.IsAAtomicRMWInst(this) : default;
+        public LLVMValueRef IsAAtomicRMWInst => LLVM.IsAAtomicRMWInst(this);
 
-        public LLVMValueRef IsABasicBlock => (Handle != IntPtr.Zero) ? LLVM.IsABasicBlock(this) : default;
+        public LLVMValueRef IsABasicBlock => LLVM.IsABasicBlock(this);
 
-        public LLVMValueRef IsABinaryOperator => (Handle != IntPtr.Zero) ? LLVM.IsABinaryOperator(this) : default;
+        public LLVMValueRef IsABinaryOperator => LLVM.IsABinaryOperator(this);
 
-        public LLVMValueRef IsABitCastInst => (Handle != IntPtr.Zero) ? LLVM.IsABitCastInst(this) : default;
+        public LLVMValueRef IsABitCastInst => LLVM.IsABitCastInst(this);
 
-        public LLVMValueRef IsABlockAddress => (Handle != IntPtr.Zero) ? LLVM.IsABlockAddress(this) : default;
+        public LLVMValueRef IsABlockAddress => LLVM.IsABlockAddress(this);
 
-        public LLVMValueRef IsABranchInst => (Handle != IntPtr.Zero) ? LLVM.IsABranchInst(this) : default;
+        public LLVMValueRef IsABranchInst => LLVM.IsABranchInst(this);
 
-        public LLVMValueRef IsACallBrInst => (Handle != IntPtr.Zero) ? LLVM.IsACallBrInst(this) : default;
+        public LLVMValueRef IsACallBrInst => LLVM.IsACallBrInst(this);
 
-        public LLVMValueRef IsACallInst => (Handle != IntPtr.Zero) ? LLVM.IsACallInst(this) : default;
+        public LLVMValueRef IsACallInst => LLVM.IsACallInst(this);
 
-        public LLVMValueRef IsACastInst => (Handle != IntPtr.Zero) ? LLVM.IsACastInst(this) : default;
+        public LLVMValueRef IsACastInst => LLVM.IsACastInst(this);
 
-        public LLVMValueRef IsACatchSwitchInst => (Handle != IntPtr.Zero) ? LLVM.IsACatchSwitchInst(this) : default;
+        public LLVMValueRef IsACatchPadInst => LLVM.IsACatchPadInst(this);
 
-        public LLVMValueRef IsACmpInst => (Handle != IntPtr.Zero) ? LLVM.IsACmpInst(this) : default;
+        public LLVMValueRef IsACatchReturnInst => LLVM.IsACatchReturnInst(this);
 
-        public LLVMValueRef IsAConstant => (Handle != IntPtr.Zero) ? LLVM.IsAConstant(this) : default;
+        public LLVMValueRef IsACatchSwitchInst => LLVM.IsACatchSwitchInst(this);
 
-        public LLVMValueRef IsAConstantAggregateZero => (Handle != IntPtr.Zero) ? LLVM.IsAConstantAggregateZero(this) : default;
+        public LLVMValueRef IsACleanupPadInst => LLVM.IsACleanupPadInst(this);
 
-        public LLVMValueRef IsAConstantArray => (Handle != IntPtr.Zero) ? LLVM.IsAConstantArray(this) : default;
+        public LLVMValueRef IsACleanupReturnInst => LLVM.IsACleanupReturnInst(this);
 
-        public LLVMValueRef IsAConstantDataArray => (Handle != IntPtr.Zero) ? LLVM.IsAConstantDataArray(this) : default;
+        public LLVMValueRef IsACmpInst => LLVM.IsACmpInst(this);
 
-        public LLVMValueRef IsAConstantDataSequential => (Handle != IntPtr.Zero) ? LLVM.IsAConstantDataSequential(this) : default;
+        public LLVMValueRef IsAConstant => LLVM.IsAConstant(this);
 
-        public LLVMValueRef IsAConstantDataVector => (Handle != IntPtr.Zero) ? LLVM.IsAConstantDataVector(this) : default;
+        public LLVMValueRef IsAConstantAggregateZero => LLVM.IsAConstantAggregateZero(this);
 
-        public LLVMValueRef IsAConstantExpr => (Handle != IntPtr.Zero) ? LLVM.IsAConstantExpr(this) : default;
+        public LLVMValueRef IsAConstantArray => LLVM.IsAConstantArray(this);
 
-        public LLVMValueRef IsAConstantFP => (Handle != IntPtr.Zero) ? LLVM.IsAConstantFP(this) : default;
+        public LLVMValueRef IsAConstantDataArray => LLVM.IsAConstantDataArray(this);
 
-        public LLVMValueRef IsAConstantInt => (Handle != IntPtr.Zero) ? LLVM.IsAConstantInt(this) : default;
+        public LLVMValueRef IsAConstantDataSequential => LLVM.IsAConstantDataSequential(this);
 
-        public LLVMValueRef IsAConstantPointerNull => (Handle != IntPtr.Zero) ? LLVM.IsAConstantPointerNull(this) : default;
+        public LLVMValueRef IsAConstantDataVector => LLVM.IsAConstantDataVector(this);
 
-        public LLVMValueRef IsAConstantStruct => (Handle != IntPtr.Zero) ? LLVM.IsAConstantStruct(this) : default;
+        public LLVMValueRef IsAConstantExpr => LLVM.IsAConstantExpr(this);
 
-        public LLVMValueRef IsAConstantVector => (Handle != IntPtr.Zero) ? LLVM.IsAConstantVector(this) : default;
+        public LLVMValueRef IsAConstantFP => LLVM.IsAConstantFP(this);
 
-        public LLVMValueRef IsADbgDeclareInst => (Handle != IntPtr.Zero) ? LLVM.IsADbgDeclareInst(this) : default;
+        public LLVMValueRef IsAConstantInt => LLVM.IsAConstantInt(this);
 
-        public LLVMValueRef IsADbgInfoIntrinsic => (Handle != IntPtr.Zero) ? LLVM.IsADbgInfoIntrinsic(this) : default;
+        public LLVMValueRef IsAConstantPointerNull => LLVM.IsAConstantPointerNull(this);
 
-        public LLVMValueRef IsAExtractElementInst => (Handle != IntPtr.Zero) ? LLVM.IsAExtractElementInst(this) : default;
+        public LLVMValueRef IsAConstantStruct => LLVM.IsAConstantStruct(this);
 
-        public LLVMValueRef IsAExtractValueInst => (Handle != IntPtr.Zero) ? LLVM.IsAExtractValueInst(this) : default;
+        public LLVMValueRef IsAConstantTokenNone => LLVM.IsAConstantTokenNone(this);
 
-        public LLVMValueRef IsAFCmpInst => (Handle != IntPtr.Zero) ?  LLVM.IsAFCmpInst(this) : default;
+        public LLVMValueRef IsAConstantVector => LLVM.IsAConstantVector(this);
 
-        public LLVMValueRef IsAFenceInst => (Handle != IntPtr.Zero) ? LLVM.IsAFenceInst(this) : default;
+        public LLVMValueRef IsADbgDeclareInst => LLVM.IsADbgDeclareInst(this);
 
-        public LLVMValueRef IsAFPExtInst => (Handle != IntPtr.Zero) ?  LLVM.IsAFPExtInst(this) : default;
+        public LLVMValueRef IsADbgInfoIntrinsic => LLVM.IsADbgInfoIntrinsic(this);
 
-        public LLVMValueRef IsAFPToSIInst => (Handle != IntPtr.Zero) ?  LLVM.IsAFPToSIInst(this) : default;
+        public LLVMValueRef IsADbgLabelInst => LLVM.IsADbgLabelInst(this);
 
-        public LLVMValueRef IsAFPToUIInst => (Handle != IntPtr.Zero) ?  LLVM.IsAFPToUIInst(this) : default;
+        public LLVMValueRef IsADbgVariableIntrinsic => LLVM.IsADbgVariableIntrinsic(this);
 
-        public LLVMValueRef IsAFPTruncInst => (Handle != IntPtr.Zero) ?  LLVM.IsAFPTruncInst(this) : default;
+        public LLVMValueRef IsAExtractElementInst => LLVM.IsAExtractElementInst(this);
 
-        public LLVMValueRef IsAFreezeInst => (Handle != IntPtr.Zero) ? LLVM.IsAFreezeInst(this) : default;
+        public LLVMValueRef IsAExtractValueInst => LLVM.IsAExtractValueInst(this);
 
-        public LLVMValueRef IsAFunction => (Handle != IntPtr.Zero) ?  LLVM.IsAFunction(this) : default;
+        public LLVMValueRef IsAFCmpInst => LLVM.IsAFCmpInst(this);
 
-        public LLVMValueRef IsAGetElementPtrInst => (Handle != IntPtr.Zero) ?  LLVM.IsAGetElementPtrInst(this) : default;
+        public LLVMValueRef IsAFenceInst => LLVM.IsAFenceInst(this);
 
-        public LLVMValueRef IsAGlobalAlias => (Handle != IntPtr.Zero) ?  LLVM.IsAGlobalAlias(this) : default;
+        public LLVMValueRef IsAFPExtInst => LLVM.IsAFPExtInst(this);
 
-        public LLVMValueRef IsAGlobalObject => (Handle != IntPtr.Zero) ?  LLVM.IsAGlobalObject(this) : default;
+        public LLVMValueRef IsAFPToSIInst => LLVM.IsAFPToSIInst(this);
 
-        public LLVMValueRef IsAGlobalValue => (Handle != IntPtr.Zero) ?  LLVM.IsAGlobalValue(this) : default;
+        public LLVMValueRef IsAFPToUIInst => LLVM.IsAFPToUIInst(this);
 
-        public LLVMValueRef IsAGlobalVariable => (Handle != IntPtr.Zero) ?  LLVM.IsAGlobalVariable(this) : default;
+        public LLVMValueRef IsAFPTruncInst => LLVM.IsAFPTruncInst(this);
 
-        public LLVMValueRef IsAICmpInst => (Handle != IntPtr.Zero) ?  LLVM.IsAICmpInst(this) : default;
+        public LLVMValueRef IsAFreezeInst => LLVM.IsAFreezeInst(this);
 
-        public LLVMValueRef IsAIndirectBrInst => (Handle != IntPtr.Zero) ?  LLVM.IsAIndirectBrInst(this) : default;
+        public LLVMValueRef IsAFuncletPadInst => LLVM.IsAFuncletPadInst(this);
 
-        public LLVMValueRef IsAInlineAsm => (Handle != IntPtr.Zero) ?  LLVM.IsAInlineAsm(this) : default;
+        public LLVMValueRef IsAFunction => LLVM.IsAFunction(this);
 
-        public LLVMValueRef IsAInsertElementInst => (Handle != IntPtr.Zero) ?  LLVM.IsAInsertElementInst(this) : default;
+        public LLVMValueRef IsAGetElementPtrInst => LLVM.IsAGetElementPtrInst(this);
 
-        public LLVMValueRef IsAInsertValueInst => (Handle != IntPtr.Zero) ?  LLVM.IsAInsertValueInst(this) : default;
+        public LLVMValueRef IsAGlobalAlias => LLVM.IsAGlobalAlias(this);
 
-        public LLVMValueRef IsAInstruction => (Handle != IntPtr.Zero) ?  LLVM.IsAInstruction(this) : default;
+        public LLVMValueRef IsAGlobalIFunc => LLVM.IsAGlobalIFunc(this);
 
-        public LLVMValueRef IsAIntrinsicInst => (Handle != IntPtr.Zero) ?  LLVM.IsAIntrinsicInst(this) : default;
+        public LLVMValueRef IsAGlobalObject => LLVM.IsAGlobalObject(this);
 
-        public LLVMValueRef IsAIntToPtrInst => (Handle != IntPtr.Zero) ?  LLVM.IsAIntToPtrInst(this) : default;
+        public LLVMValueRef IsAGlobalValue => LLVM.IsAGlobalValue(this);
 
-        public LLVMValueRef IsAInvokeInst => (Handle != IntPtr.Zero) ?  LLVM.IsAInvokeInst(this) : default;
+        public LLVMValueRef IsAGlobalVariable => LLVM.IsAGlobalVariable(this);
 
-        public LLVMValueRef IsALandingPadInst => (Handle != IntPtr.Zero) ?  LLVM.IsALandingPadInst(this) : default;
+        public LLVMValueRef IsAICmpInst => LLVM.IsAICmpInst(this);
 
-        public LLVMValueRef IsALoadInst => (Handle != IntPtr.Zero) ?  LLVM.IsALoadInst(this) : default;
+        public LLVMValueRef IsAIndirectBrInst => LLVM.IsAIndirectBrInst(this);
 
-        public LLVMValueRef IsAMDNode => (Handle != IntPtr.Zero) ?  LLVM.IsAMDNode(this) : default;
+        public LLVMValueRef IsAInlineAsm => LLVM.IsAInlineAsm(this);
 
-        public LLVMValueRef IsAMDString => (Handle != IntPtr.Zero) ?  LLVM.IsAMDString(this) : default;
+        public LLVMValueRef IsAInsertElementInst => LLVM.IsAInsertElementInst(this);
 
-        public LLVMValueRef IsAMemCpyInst => (Handle != IntPtr.Zero) ?  LLVM.IsAMemCpyInst(this) : default;
+        public LLVMValueRef IsAInsertValueInst => LLVM.IsAInsertValueInst(this);
 
-        public LLVMValueRef IsAMemIntrinsic => (Handle != IntPtr.Zero) ?  LLVM.IsAMemIntrinsic(this) : default;
+        public LLVMValueRef IsAInstruction => LLVM.IsAInstruction(this);
 
-        public LLVMValueRef IsAMemMoveInst => (Handle != IntPtr.Zero) ?  LLVM.IsAMemMoveInst(this) : default;
+        public LLVMValueRef IsAIntrinsicInst => LLVM.IsAIntrinsicInst(this);
 
-        public LLVMValueRef IsAMemSetInst => (Handle != IntPtr.Zero) ?  LLVM.IsAMemSetInst(this) : default;
+        public LLVMValueRef IsAIntToPtrInst => LLVM.IsAIntToPtrInst(this);
 
-        public LLVMValueRef IsAPHINode => (Handle != IntPtr.Zero) ?  LLVM.IsAPHINode(this) : default;
+        public LLVMValueRef IsAInvokeInst => LLVM.IsAInvokeInst(this);
 
-        public LLVMValueRef IsAPtrToIntInst => (Handle != IntPtr.Zero) ?  LLVM.IsAPtrToIntInst(this) : default;
+        public LLVMValueRef IsALandingPadInst => LLVM.IsALandingPadInst(this);
 
-        public LLVMValueRef IsAResumeInst => (Handle != IntPtr.Zero) ?  LLVM.IsAResumeInst(this) : default;
+        public LLVMValueRef IsALoadInst => LLVM.IsALoadInst(this);
 
-        public LLVMValueRef IsAReturnInst => (Handle != IntPtr.Zero) ?  LLVM.IsAReturnInst(this) : default;
+        public LLVMValueRef IsAMDNode => LLVM.IsAMDNode(this);
 
-        public LLVMValueRef IsASelectInst => (Handle != IntPtr.Zero) ?  LLVM.IsASelectInst(this) : default;
+        public LLVMValueRef IsAMDString => LLVM.IsAMDString(this);
 
-        public LLVMValueRef IsASExtInst => (Handle != IntPtr.Zero) ?  LLVM.IsASExtInst(this) : default;
+        public LLVMValueRef IsAMemCpyInst => LLVM.IsAMemCpyInst(this);
 
-        public LLVMValueRef IsAShuffleVectorInst => (Handle != IntPtr.Zero) ?  LLVM.IsAShuffleVectorInst(this) : default;
+        public LLVMValueRef IsAMemIntrinsic => LLVM.IsAMemIntrinsic(this);
 
-        public LLVMValueRef IsASIToFPInst => (Handle != IntPtr.Zero) ?  LLVM.IsASIToFPInst(this) : default;
+        public LLVMValueRef IsAMemMoveInst => LLVM.IsAMemMoveInst(this);
 
-        public LLVMValueRef IsAStoreInst => (Handle != IntPtr.Zero) ?  LLVM.IsAStoreInst(this) : default;
+        public LLVMValueRef IsAMemSetInst => LLVM.IsAMemSetInst(this);
 
-        public LLVMValueRef IsASwitchInst => (Handle != IntPtr.Zero) ?  LLVM.IsASwitchInst(this) : default;
+        public LLVMValueRef IsAPHINode => LLVM.IsAPHINode(this);
 
-        public LLVMValueRef IsATerminatorInst => (Handle != IntPtr.Zero) ?  LLVM.IsATerminatorInst(this) : default;
+        public LLVMValueRef IsAPtrToIntInst => LLVM.IsAPtrToIntInst(this);
 
-        public LLVMValueRef IsATruncInst => (Handle != IntPtr.Zero) ?  LLVM.IsATruncInst(this) : default;
+        public LLVMValueRef IsAResumeInst => LLVM.IsAResumeInst(this);
 
-        public LLVMValueRef IsAUIToFPInst => (Handle != IntPtr.Zero) ?  LLVM.IsAUIToFPInst(this) : default;
+        public LLVMValueRef IsAReturnInst => LLVM.IsAReturnInst(this);
 
-        public LLVMValueRef IsAUnaryInstruction => (Handle != IntPtr.Zero) ?  LLVM.IsAUnaryInstruction(this) : default;
+        public LLVMValueRef IsASelectInst => LLVM.IsASelectInst(this);
 
-        public LLVMValueRef IsAUnaryOperator => (Handle != IntPtr.Zero) ? LLVM.IsAUnaryOperator(this) : default;
+        public LLVMValueRef IsASExtInst => LLVM.IsASExtInst(this);
 
-        public LLVMValueRef IsAUndefValue => (Handle != IntPtr.Zero) ?  LLVM.IsAUndefValue(this) : default;
+        public LLVMValueRef IsAShuffleVectorInst => LLVM.IsAShuffleVectorInst(this);
 
-        public LLVMValueRef IsAUnreachableInst => (Handle != IntPtr.Zero) ?  LLVM.IsAUnreachableInst(this) : default;
+        public LLVMValueRef IsASIToFPInst => LLVM.IsASIToFPInst(this);
 
-        public LLVMValueRef IsAUser => (Handle != IntPtr.Zero) ?  LLVM.IsAUser(this) : default;
+        public LLVMValueRef IsAStoreInst => LLVM.IsAStoreInst(this);
 
-        public LLVMValueRef IsAVAArgInst => (Handle != IntPtr.Zero) ?  LLVM.IsAVAArgInst(this) : default;
+        public LLVMValueRef IsASwitchInst => LLVM.IsASwitchInst(this);
 
-        public LLVMValueRef IsAZExtInst => (Handle != IntPtr.Zero) ?  LLVM.IsAZExtInst(this) : default;
+        public LLVMValueRef IsATerminatorInst => LLVM.IsATerminatorInst(this);
 
-        public bool IsBasicBlock => (Handle != IntPtr.Zero) ?  LLVM.ValueIsBasicBlock(this) != 0 : default;
+        public LLVMValueRef IsATruncInst => LLVM.IsATruncInst(this);
+
+        public LLVMValueRef IsAUIToFPInst => LLVM.IsAUIToFPInst(this);
+
+        public LLVMValueRef IsAUnaryInstruction => LLVM.IsAUnaryInstruction(this);
+
+        public LLVMValueRef IsAUnaryOperator => LLVM.IsAUnaryOperator(this);
+
+        public LLVMValueRef IsAUndefValue => LLVM.IsAUndefValue(this);
+
+        public LLVMValueRef IsAUnreachableInst => LLVM.IsAUnreachableInst(this);
+
+        public LLVMValueRef IsAUser => LLVM.IsAUser(this);
+
+        public LLVMValueRef IsAVAArgInst => LLVM.IsAVAArgInst(this);
+
+        public LLVMValueRef IsAZExtInst => LLVM.IsAZExtInst(this);
+
+        public bool IsBasicBlock => (Handle != IntPtr.Zero) ? LLVM.ValueIsBasicBlock(this) != 0 : default;
 
         public bool IsCleanup
         {
-            get => (Handle != IntPtr.Zero) ? LLVM.IsCleanup(this) != 0 : default;
+            get => (IsALandingPadInst != null) ? LLVM.IsCleanup(this) != 0 : default;
             set => LLVM.SetCleanup(this, value ? 1 : 0);
         }
 
-        public bool IsConditional => (Handle != IntPtr.Zero) ? LLVM.IsConditional(this) != 0 : default;
+        public bool IsConditional => (IsABranchInst != null) ? LLVM.IsConditional(this) != 0 : default;
 
         public bool IsConstant => (Handle != IntPtr.Zero) ? LLVM.IsConstant(this) != 0 : default;
 
-        public bool IsConstantString => (Handle != IntPtr.Zero) ? LLVM.IsConstantString(this) != 0 : default;
+        public bool IsConstantString => (IsAConstantDataSequential != null) ? LLVM.IsConstantString(this) != 0 : default;
 
-        public bool IsDeclaration => (Handle != IntPtr.Zero) ? LLVM.IsDeclaration(this) != 0 : default;
+        public bool IsDeclaration => (IsAGlobalValue != null) ? LLVM.IsDeclaration(this) != 0 : default;
 
         public bool IsExternallyInitialized
         {
-            get => (Handle != IntPtr.Zero) ? LLVM.IsExternallyInitialized(this) != 0 : default;
+            get => (IsAGlobalVariable != null) ? LLVM.IsExternallyInitialized(this) != 0 : default;
             set => LLVM.SetExternallyInitialized(this, value ? 1 : 0);
         }
 
         public bool IsGlobalConstant
         {
-            get => (Handle != IntPtr.Zero) ? LLVM.IsGlobalConstant(this) != 0 : default;
+            get => (IsAGlobalVariable != null) ? LLVM.IsGlobalConstant(this) != 0 : default;
             set => LLVM.SetGlobalConstant(this, value ? 1 : 0);
 
         }
@@ -349,25 +365,27 @@ namespace LLVMSharp.Interop
 
         public bool IsTailCall
         {
-            get => (Handle != IntPtr.Zero) ? LLVM.IsTailCall(this) != 0 : default;
+            get => (IsACallInst != null) ? LLVM.IsTailCall(this) != 0 : default;
             set => LLVM.SetTailCall(this, IsTailCall ? 1 : 0);
         }
 
         public bool IsThreadLocal
         {
-            get => (Handle != IntPtr.Zero) ? LLVM.IsThreadLocal(this) != 0 : default;
+            get => (IsAGlobalVariable != null) ? LLVM.IsThreadLocal(this) != 0 : default;
             set => LLVM.SetThreadLocal(this, value ? 1 : 0);
         }
 
         public bool IsUndef => (Handle != IntPtr.Zero) ? LLVM.IsUndef(this) != 0 : default;
 
-        public LLVMBasicBlockRef LastBasicBlock => (Handle != IntPtr.Zero) ? LLVM.GetLastBasicBlock(this) : default;
+        public LLVMValueKind Kind => (Handle != IntPtr.Zero) ? LLVM.GetValueKind(this) : default;
 
-        public LLVMValueRef LastParam => (Handle != IntPtr.Zero) ? LLVM.GetLastParam(this) : default;
+        public LLVMBasicBlockRef LastBasicBlock => (IsAFunction != null) ? LLVM.GetLastBasicBlock(this) : default;
+
+        public LLVMValueRef LastParam => (IsAFunction != null) ? LLVM.GetLastParam(this) : default;
 
         public LLVMLinkage Linkage
         {
-            get => (Handle != IntPtr.Zero) ? LLVM.GetLinkage(this) : default;
+            get => (IsAGlobalValue != null) ? LLVM.GetLinkage(this) : default;
             set => LLVM.SetLinkage(this, value);
         }
 
@@ -375,7 +393,7 @@ namespace LLVMSharp.Interop
         {
             get
             {
-                if (Handle == IntPtr.Zero)
+                if (Kind != LLVMValueKind.LLVMMetadataAsValueValueKind)
                 {
                     return Array.Empty<LLVMValueRef>();
                 }
@@ -391,7 +409,7 @@ namespace LLVMSharp.Interop
             }
         }
 
-        public uint MDNodeOperandsCount => (Handle != IntPtr.Zero) ? LLVM.GetMDNodeNumOperands(this) : default;
+        public uint MDNodeOperandsCount => (Kind != LLVMValueKind.LLVMMetadataAsValueValueKind) ? LLVM.GetMDNodeNumOperands(this) : default;
 
         public string Name
         {
@@ -415,26 +433,26 @@ namespace LLVMSharp.Interop
 
             set
             {
-                using var marshaledName = new MarshaledString(value);
+                using var marshaledName = new MarshaledString(value.AsSpan());
                 LLVM.SetValueName(this, marshaledName);
             }
         }
 
-        public LLVMValueRef NextFunction => (Handle != IntPtr.Zero) ? LLVM.GetNextFunction(this) : default;
+        public LLVMValueRef NextFunction => (IsAFunction != null) ? LLVM.GetNextFunction(this) : default;
 
-        public LLVMValueRef NextGlobal => (Handle != IntPtr.Zero) ? LLVM.GetNextGlobal(this) : default;
+        public LLVMValueRef NextGlobal => (IsAGlobalVariable != null) ? LLVM.GetNextGlobal(this) : default;
 
-        public LLVMValueRef NextInstruction => (Handle != IntPtr.Zero) ? LLVM.GetNextInstruction(this) : default;
+        public LLVMValueRef NextInstruction => (IsAInstruction != null) ? LLVM.GetNextInstruction(this) : default;
 
-        public LLVMValueRef NextParam => (Handle != IntPtr.Zero) ? LLVM.GetNextParam(this) : default;
+        public LLVMValueRef NextParam => (IsAArgument != null) ? LLVM.GetNextParam(this) : default;
 
-        public int OperandCount => (Handle != IntPtr.Zero) ? LLVM.GetNumOperands(this) : default;
+        public int OperandCount => ((Kind == LLVMValueKind.LLVMMetadataAsValueValueKind) || (IsAUser != null)) ? LLVM.GetNumOperands(this) : default;
 
         public LLVMValueRef[] Params
         {
             get
             {
-                if (Handle == IntPtr.Zero)
+                if (IsAFunction == null)
                 {
                     return Array.Empty<LLVMValueRef>();
                 }
@@ -450,29 +468,29 @@ namespace LLVMSharp.Interop
             }
         }
 
-        public uint ParamsCount => (Handle != IntPtr.Zero) ? LLVM.CountParams(this) : default;
+        public uint ParamsCount => (IsAFunction != null) ? LLVM.CountParams(this) : default;
 
-        public LLVMValueRef ParamParent => (Handle != IntPtr.Zero) ? LLVM.GetParamParent(this) : default;
+        public LLVMValueRef ParamParent => (IsAArgument != null) ? LLVM.GetParamParent(this) : default;
 
         public LLVMValueRef PersonalityFn
         {
-            get => (Handle != IntPtr.Zero) ? LLVM.GetPersonalityFn(this) : default;
+            get => (IsAFunction != null) ? LLVM.GetPersonalityFn(this) : default;
             set => LLVM.SetPersonalityFn(this, value);
         }
 
-        public LLVMValueRef PreviousGlobal => (Handle != IntPtr.Zero) ? LLVM.GetPreviousGlobal(this) : default;
+        public LLVMValueRef PreviousGlobal => (IsAGlobalVariable != null) ? LLVM.GetPreviousGlobal(this) : default;
 
-        public LLVMValueRef PreviousInstruction => (Handle != IntPtr.Zero) ? LLVM.GetPreviousInstruction(this) : default;
+        public LLVMValueRef PreviousInstruction => (IsAInstruction != null) ? LLVM.GetPreviousInstruction(this) : default;
 
-        public LLVMValueRef PreviousParam => (Handle != IntPtr.Zero) ? LLVM.GetPreviousParam(this) : default;
+        public LLVMValueRef PreviousParam => (IsAArgument != null) ? LLVM.GetPreviousParam(this) : default;
 
-        public LLVMValueRef PreviousFunction => (Handle != IntPtr.Zero) ? LLVM.GetPreviousFunction(this) : default;
+        public LLVMValueRef PreviousFunction => (IsAFunction != null) ? LLVM.GetPreviousFunction(this) : default;
 
         public string Section
         {
             get
             {
-                if (Handle == IntPtr.Zero)
+                if (IsAGlobalValue == null)
                 {
                     return string.Empty;
                 }
@@ -490,18 +508,18 @@ namespace LLVMSharp.Interop
 
             set
             {
-                using var marshaledSection = new MarshaledString(value);
+                using var marshaledSection = new MarshaledString(value.AsSpan());
                 LLVM.SetSection(this, marshaledSection);
             }
         }
 
-        public uint SuccessorsCount => (Handle != IntPtr.Zero) ? LLVM.GetNumSuccessors(this) : default;
+        public uint SuccessorsCount => (IsAInstruction != null) ? LLVM.GetNumSuccessors(this) : default;
 
-        public LLVMBasicBlockRef SwitchDefaultDest => (Handle != IntPtr.Zero) ? LLVM.GetSwitchDefaultDest(this) : default;
+        public LLVMBasicBlockRef SwitchDefaultDest => (IsASwitchInst != null) ? LLVM.GetSwitchDefaultDest(this) : default;
 
         public LLVMThreadLocalMode ThreadLocalMode
         {
-            get => (Handle != IntPtr.Zero) ? LLVM.GetThreadLocalMode(this) : default;
+            get => (IsAGlobalVariable != null) ? LLVM.GetThreadLocalMode(this) : default;
             set => LLVM.SetThreadLocalMode(this, value);
         }
 
@@ -509,19 +527,19 @@ namespace LLVMSharp.Interop
 
         public LLVMVisibility Visibility
         {
-            get => (Handle != IntPtr.Zero) ? LLVM.GetVisibility(this) : default;
+            get => (IsAGlobalValue != null) ? LLVM.GetVisibility(this) : default;
             set => LLVM.SetVisibility(this, value);
         }
 
         public bool Volatile
         {
-            get => (Handle != IntPtr.Zero) ? LLVM.GetVolatile(this) != 0 : default;
+            get => ((IsALoadInst != null) || (IsAStoreInst != null) || (IsAAtomicRMWInst != null) || (IsAAtomicCmpXchgInst != null)) ? LLVM.GetVolatile(this) != 0 : default;
             set => LLVM.SetVolatile(this, value ? 1 : 0);
         }
 
         public bool Weak
         {
-            get => (Handle != IntPtr.Zero) ? LLVM.GetWeak(this) != 0 : default;
+            get => (IsAAtomicCmpXchgInst != null) ? LLVM.GetWeak(this) != 0 : default;
             set => LLVM.SetWeak(this, value ? 1 : 0);
         }
 
@@ -537,11 +555,13 @@ namespace LLVMSharp.Interop
 
         public static LLVMValueRef CreateConstAnd(LLVMValueRef LHSConstant, LLVMValueRef RHSConstant) => LLVM.ConstAnd(LHSConstant, RHSConstant);
 
-        public static LLVMValueRef CreateConstArray(LLVMTypeRef ElementTy, LLVMValueRef[] ConstantVals)
+        public static LLVMValueRef CreateConstArray(LLVMTypeRef ElementTy, LLVMValueRef[] ConstantVals) => CreateConstArray(ElementTy, ConstantVals.AsSpan());
+
+        public static LLVMValueRef CreateConstArray(LLVMTypeRef ElementTy, ReadOnlySpan<LLVMValueRef> ConstantVals)
         {
             fixed (LLVMValueRef* pConstantVals = ConstantVals)
             {
-                return LLVM.ConstArray(ElementTy, (LLVMOpaqueValue**)pConstantVals, (uint)ConstantVals?.Length);
+                return LLVM.ConstArray(ElementTy, (LLVMOpaqueValue**)pConstantVals, (uint)ConstantVals.Length);
             }
         }
 
@@ -555,11 +575,13 @@ namespace LLVMSharp.Interop
 
         public static LLVMValueRef CreateConstExtractElement(LLVMValueRef VectorConstant, LLVMValueRef IndexConstant) => LLVM.ConstExtractElement(VectorConstant, IndexConstant);
 
-        public static LLVMValueRef CreateConstExtractValue(LLVMValueRef AggConstant, uint[] IdxList)
+        public static LLVMValueRef CreateConstExtractValue(LLVMValueRef AggConstant, uint[] IdxList) => CreateConstExtractValue(AggConstant, IdxList.AsSpan());
+
+        public static LLVMValueRef CreateConstExtractValue(LLVMValueRef AggConstant, ReadOnlySpan<uint> IdxList)
         {
             fixed (uint* pIdxList = IdxList)
             {
-                return LLVM.ConstExtractValue(AggConstant, pIdxList, (uint)IdxList?.Length);
+                return LLVM.ConstExtractValue(AggConstant, pIdxList, (uint)IdxList.Length);
             }
         }
 
@@ -585,23 +607,29 @@ namespace LLVMSharp.Interop
 
         public static LLVMValueRef CreateConstFSub(LLVMValueRef LHSConstant, LLVMValueRef RHSConstant) => LLVM.ConstFSub(LHSConstant, RHSConstant);
 
-        public static LLVMValueRef CreateConstGEP(LLVMValueRef ConstantVal, LLVMValueRef[] ConstantIndices)
+        public static LLVMValueRef CreateConstGEP(LLVMValueRef ConstantVal, LLVMValueRef[] ConstantIndices) => CreateConstGEP(ConstantVal, ConstantIndices.AsSpan());
+
+        public static LLVMValueRef CreateConstGEP(LLVMValueRef ConstantVal, ReadOnlySpan<LLVMValueRef> ConstantIndices)
         {
             fixed (LLVMValueRef* pConstantIndices = ConstantIndices)
             {
-                return LLVM.ConstGEP(ConstantVal, (LLVMOpaqueValue**)pConstantIndices, (uint)ConstantIndices?.Length);
+                return LLVM.ConstGEP(ConstantVal, (LLVMOpaqueValue**)pConstantIndices, (uint)ConstantIndices.Length);
             }
         }
 
-        public static LLVMValueRef CreateConstInBoundsGEP(LLVMValueRef ConstantVal, LLVMValueRef[] ConstantIndices)
+        public static LLVMValueRef CreateConstInBoundsGEP(LLVMValueRef ConstantVal, LLVMValueRef[] ConstantIndices) => CreateConstInBoundsGEP(ConstantVal, ConstantIndices.AsSpan());
+
+        public static LLVMValueRef CreateConstInBoundsGEP(LLVMValueRef ConstantVal, ReadOnlySpan<LLVMValueRef> ConstantIndices)
         {
             fixed (LLVMValueRef* pConstantIndices = ConstantIndices)
             {
-                return LLVM.ConstInBoundsGEP(ConstantVal, (LLVMOpaqueValue**)pConstantIndices, (uint)ConstantIndices?.Length);
+                return LLVM.ConstInBoundsGEP(ConstantVal, (LLVMOpaqueValue**)pConstantIndices, (uint)ConstantIndices.Length);
             }
         }
 
-        public static LLVMValueRef CreateConstInlineAsm(LLVMTypeRef Ty, string AsmString, string Constraints, bool HasSideEffects, bool IsAlignStack)
+        public static LLVMValueRef CreateConstInlineAsm(LLVMTypeRef Ty, string AsmString, string Constraints, bool HasSideEffects, bool IsAlignStack) => CreateConstInlineAsm(Ty, AsmString.AsSpan(), Constraints.AsSpan(), HasSideEffects, IsAlignStack);
+
+        public static LLVMValueRef CreateConstInlineAsm(LLVMTypeRef Ty, ReadOnlySpan<char> AsmString, ReadOnlySpan<char> Constraints, bool HasSideEffects, bool IsAlignStack)
         {
             using var marshaledAsmString = new MarshaledString(AsmString);
             using var marshaledConstraints = new MarshaledString(Constraints);
@@ -610,11 +638,13 @@ namespace LLVMSharp.Interop
 
         public static LLVMValueRef CreateConstInsertElement(LLVMValueRef VectorConstant, LLVMValueRef ElementValueConstant, LLVMValueRef IndexConstant) => LLVM.ConstInsertElement(VectorConstant, ElementValueConstant, IndexConstant);
 
-        public static LLVMValueRef CreateConstInsertValue(LLVMValueRef AggConstant, LLVMValueRef ElementValueConstant, uint[] IdxList)
+        public static LLVMValueRef CreateConstInsertValue(LLVMValueRef AggConstant, LLVMValueRef ElementValueConstant, uint[] IdxList) => CreateConstInsertValue(AggConstant, ElementValueConstant, IdxList.AsSpan());
+
+        public static LLVMValueRef CreateConstInsertValue(LLVMValueRef AggConstant, LLVMValueRef ElementValueConstant, ReadOnlySpan<uint> IdxList)
         {
             fixed (uint* pIdxList = IdxList)
             {
-                return LLVM.ConstInsertValue(AggConstant, ElementValueConstant, pIdxList, (uint)IdxList?.Length);
+                return LLVM.ConstInsertValue(AggConstant, ElementValueConstant, pIdxList, (uint)IdxList.Length);
             }
         }
 
@@ -622,24 +652,30 @@ namespace LLVMSharp.Interop
 
         public static LLVMValueRef CreateConstIntCast(LLVMValueRef ConstantVal, LLVMTypeRef ToType, bool isSigned) => LLVM.ConstIntCast(ConstantVal, ToType, isSigned ? 1 : 0);
 
-        public static LLVMValueRef CreateConstIntOfArbitraryPrecision(LLVMTypeRef IntTy, ulong[] Words)
+        public static LLVMValueRef CreateConstIntOfArbitraryPrecision(LLVMTypeRef IntTy, ulong[] Words) => CreateConstIntOfArbitraryPrecision(IntTy, Words.AsSpan());
+
+        public static LLVMValueRef CreateConstIntOfArbitraryPrecision(LLVMTypeRef IntTy, ReadOnlySpan<ulong> Words)
         {
             fixed (ulong* pWords = Words)
             {
-                return LLVM.ConstIntOfArbitraryPrecision(IntTy, (uint)Words?.Length, pWords);
+                return LLVM.ConstIntOfArbitraryPrecision(IntTy, (uint)Words.Length, pWords);
             }
         }
 
-        public static LLVMValueRef CreateConstIntOfString(LLVMTypeRef IntTy, string Text, byte Radix)
+        public static LLVMValueRef CreateConstIntOfString(LLVMTypeRef IntTy, string Text, byte Radix) => CreateConstIntOfString(IntTy, Text.AsSpan(), Radix);
+
+        public static LLVMValueRef CreateConstIntOfString(LLVMTypeRef IntTy, ReadOnlySpan<char> Text, byte Radix)
         {
             using var marshaledText = new MarshaledString(Text);
             return LLVM.ConstIntOfString(IntTy, marshaledText, Radix);
         }
 
-        public static LLVMValueRef CreateConstIntOfStringAndSize(LLVMTypeRef IntTy, string Text, uint SLen, byte Radix)
+        public static LLVMValueRef CreateConstIntOfStringAndSize(LLVMTypeRef IntTy, string Text, uint SLen, byte Radix) => CreateConstIntOfStringAndSize(IntTy, Text.AsSpan(0, (int)SLen), Radix);
+
+        public static LLVMValueRef CreateConstIntOfStringAndSize(LLVMTypeRef IntTy, ReadOnlySpan<char> Text, byte Radix)
         {
             using var marshaledText = new MarshaledString(Text);
-            return LLVM.ConstIntOfStringAndSize(IntTy, marshaledText, SLen, Radix);
+            return LLVM.ConstIntOfStringAndSize(IntTy, marshaledText, (uint)marshaledText.Length, Radix);
         }
 
         public static LLVMValueRef CreateConstIntToPtr(LLVMValueRef ConstantVal, LLVMTypeRef ToType) => LLVM.ConstIntToPtr(ConstantVal, ToType);
@@ -648,11 +684,13 @@ namespace LLVMSharp.Interop
 
         public static LLVMValueRef CreateConstMul(LLVMValueRef LHSConstant, LLVMValueRef RHSConstant) => LLVM.ConstMul(LHSConstant, RHSConstant);
 
-        public static LLVMValueRef CreateConstNamedStruct(LLVMTypeRef StructTy, LLVMValueRef[] ConstantVals)
+        public static LLVMValueRef CreateConstNamedStruct(LLVMTypeRef StructTy, LLVMValueRef[] ConstantVals) => CreateConstNamedStruct(StructTy, ConstantVals.AsSpan());
+
+        public static LLVMValueRef CreateConstNamedStruct(LLVMTypeRef StructTy, ReadOnlySpan<LLVMValueRef> ConstantVals)
         {
             fixed (LLVMValueRef* pConstantVals = ConstantVals)
             {
-                return LLVM.ConstNamedStruct(StructTy, (LLVMOpaqueValue**)pConstantVals, (uint)ConstantVals?.Length);
+                return LLVM.ConstNamedStruct(StructTy, (LLVMOpaqueValue**)pConstantVals, (uint)ConstantVals.Length);
             }
         }
 
@@ -688,16 +726,20 @@ namespace LLVMSharp.Interop
 
         public static LLVMValueRef CreateConstReal(LLVMTypeRef RealTy, double N) => LLVM.ConstReal(RealTy, N);
 
-        public static LLVMValueRef CreateConstRealOfString(LLVMTypeRef RealTy, string Text)
+        public static LLVMValueRef CreateConstRealOfString(LLVMTypeRef RealTy, string Text) => CreateConstRealOfString(RealTy, Text.AsSpan());
+
+        public static LLVMValueRef CreateConstRealOfString(LLVMTypeRef RealTy, ReadOnlySpan<char> Text)
         {
             using var marshaledText = new MarshaledString(Text);
             return LLVM.ConstRealOfString(RealTy, marshaledText);
         }
 
-        public static LLVMValueRef CreateConstRealOfStringAndSize(LLVMTypeRef RealTy, string Text, uint SLen)
+        public static LLVMValueRef CreateConstRealOfStringAndSize(LLVMTypeRef RealTy, string Text, uint SLen) => CreateConstRealOfStringAndSize(RealTy, Text.AsSpan(0, (int)SLen));
+
+        public static LLVMValueRef CreateConstRealOfStringAndSize(LLVMTypeRef RealTy, ReadOnlySpan<char> Text)
         {
             using var marshaledText = new MarshaledString(Text);
-            return LLVM.ConstRealOfStringAndSize(RealTy, marshaledText, SLen);
+            return LLVM.ConstRealOfStringAndSize(RealTy, marshaledText, (uint)marshaledText.Length);
         }
 
         public static LLVMValueRef CreateConstSDiv(LLVMValueRef LHSConstant, LLVMValueRef RHSConstant) => LLVM.ConstSDiv(LHSConstant, RHSConstant);
@@ -716,11 +758,13 @@ namespace LLVMSharp.Interop
 
         public static LLVMValueRef CreateConstSRem(LLVMValueRef LHSConstant, LLVMValueRef RHSConstant) => LLVM.ConstSRem(LHSConstant, RHSConstant);
 
-        public static LLVMValueRef CreateConstStruct(LLVMValueRef[] ConstantVals, bool Packed)
+        public static LLVMValueRef CreateConstStruct(LLVMValueRef[] ConstantVals, bool Packed) => CreateConstStruct(ConstantVals.AsSpan(), Packed);
+
+        public static LLVMValueRef CreateConstStruct(ReadOnlySpan<LLVMValueRef> ConstantVals, bool Packed)
         {
             fixed (LLVMValueRef* pConstantVals = ConstantVals)
             {
-                return LLVM.ConstStruct((LLVMOpaqueValue**)pConstantVals, (uint)ConstantVals?.Length, Packed ? 1 : 0);
+                return LLVM.ConstStruct((LLVMOpaqueValue**)pConstantVals, (uint)ConstantVals.Length, Packed ? 1 : 0);
             }
         }
 
@@ -736,11 +780,13 @@ namespace LLVMSharp.Interop
 
         public static LLVMValueRef CreateConstURem(LLVMValueRef LHSConstant, LLVMValueRef RHSConstant) => LLVM.ConstURem(LHSConstant, RHSConstant);
 
-        public static LLVMValueRef CreateConstVector(LLVMValueRef[] ScalarConstantVars)
+        public static LLVMValueRef CreateConstVector(LLVMValueRef[] ScalarConstantVars) => CreateConstVector(ScalarConstantVars.AsSpan());
+
+        public static LLVMValueRef CreateConstVector(ReadOnlySpan<LLVMValueRef> ScalarConstantVars)
         {
             fixed (LLVMValueRef* pScalarConstantVars = ScalarConstantVars)
             {
-                return LLVM.ConstVector((LLVMOpaqueValue**)pScalarConstantVars, (uint)ScalarConstantVars?.Length);
+                return LLVM.ConstVector((LLVMOpaqueValue**)pScalarConstantVars, (uint)ScalarConstantVars.Length);
             }
         }
 
@@ -750,11 +796,13 @@ namespace LLVMSharp.Interop
 
         public static LLVMValueRef CreateConstZExtOrBitCast(LLVMValueRef ConstantVal, LLVMTypeRef ToType) => LLVM.ConstZExtOrBitCast(ConstantVal, ToType);
 
-        public static LLVMValueRef CreateMDNode(LLVMValueRef[] Vals)
+        public static LLVMValueRef CreateMDNode(LLVMValueRef[] Vals) => CreateMDNode(Vals.AsSpan());
+
+        public static LLVMValueRef CreateMDNode(ReadOnlySpan<LLVMValueRef> Vals)
         {
             fixed (LLVMValueRef* pVals = Vals)
             {
-                return LLVM.MDNode((LLVMOpaqueValue**)pVals, (uint)Vals?.Length);
+                return LLVM.MDNode((LLVMOpaqueValue**)pVals, (uint)Vals.Length);
             }
         }
 
@@ -764,7 +812,9 @@ namespace LLVMSharp.Interop
 
         public void AddDestination(LLVMBasicBlockRef Dest) => LLVM.AddDestination(this, Dest);
 
-        public void AddIncoming(LLVMValueRef[] IncomingValues, LLVMBasicBlockRef[] IncomingBlocks, uint Count)
+        public void AddIncoming(LLVMValueRef[] IncomingValues, LLVMBasicBlockRef[] IncomingBlocks, uint Count) => AddIncoming(IncomingValues.AsSpan(), IncomingBlocks.AsSpan(), Count);
+
+        public void AddIncoming(ReadOnlySpan<LLVMValueRef> IncomingValues, ReadOnlySpan<LLVMBasicBlockRef> IncomingBlocks, uint Count)
         {
             fixed (LLVMValueRef* pIncomingValues = IncomingValues)
             fixed (LLVMBasicBlockRef* pIncomingBlocks = IncomingBlocks)
@@ -773,18 +823,24 @@ namespace LLVMSharp.Interop
             }
         }
 
-        public void AddTargetDependentFunctionAttr(string A, string V)
+        public void AddTargetDependentFunctionAttr(string A, string V) => AddTargetDependentFunctionAttr(A.AsSpan(), V.AsSpan());
+
+        public void AddTargetDependentFunctionAttr(ReadOnlySpan<char> A, ReadOnlySpan<char> V)
         {
             using var marshaledA = new MarshaledString(A);
             using var marshaledV = new MarshaledString(V);
             LLVM.AddTargetDependentFunctionAttr(this, marshaledA, marshaledV);
         }
 
-        public LLVMBasicBlockRef AppendBasicBlock(string Name)
+        public LLVMBasicBlockRef AppendBasicBlock(string Name) => AppendBasicBlock(Name.AsSpan());
+
+        public LLVMBasicBlockRef AppendBasicBlock(ReadOnlySpan<char> Name)
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.AppendBasicBlock(this, marshaledName);
         }
+
+        public LLVMBasicBlockRef AsBasicBlock() => LLVM.ValueAsBasicBlock(this);
 
         public void DeleteFunction() => LLVM.DeleteFunction(this);
 


### PR DESCRIPTION
As per the title, this adds overloads that take `Span` or `ReadOnlySpan` to most of the interop extensions