### PR TITLE
Add a proper managed wrapper for LLVMSharp

### DIFF
--- a/Tests/LLVMSharp.UnitTests/Properties/launchSettings.json
+++ b/Tests/LLVMSharp.UnitTests/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "LLVMSharp.UnitTests": {
+      "commandName": "Project",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/sources/LLVMSharp/AtomicOrdering.cs
+++ b/sources/LLVMSharp/AtomicOrdering.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public enum AtomicOrdering
+    {
+        NotAtomic = LLVMAtomicOrdering.LLVMAtomicOrderingNotAtomic,
+        Unordered = LLVMAtomicOrdering.LLVMAtomicOrderingUnordered,
+        Monotonic = LLVMAtomicOrdering.LLVMAtomicOrderingMonotonic,
+        Acquire = LLVMAtomicOrdering.LLVMAtomicOrderingAcquire,
+        Release = LLVMAtomicOrdering.LLVMAtomicOrderingRelease,
+        AcquireRelease = LLVMAtomicOrdering.LLVMAtomicOrderingAcquireRelease,
+        SequentiallyConsistent = LLVMAtomicOrdering.LLVMAtomicOrderingSequentiallyConsistent,
+    }
+}

--- a/sources/LLVMSharp/IRBuilder.cs
+++ b/sources/LLVMSharp/IRBuilder.cs
@@ -1,0 +1,695 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using System;
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class IRBuilder : IRBuilderBase
+    {
+        public IRBuilder(LLVMContext C) : base(C)
+        {
+        }
+
+        public Value CreateAdd(Value LHS, Value RHS, string Name ="") => CreateAdd(LHS, RHS, Name.AsSpan());
+
+        public Value CreateAdd(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildAdd(LHS.Handle, RHS.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateAddrSpaceCast(Value V, Type DestTy, string Name = "") => CreateAddrSpaceCast(V, DestTy, Name.AsSpan());
+
+        public Value CreateAddrSpaceCast(Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildAddrSpaceCast(V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public ReturnInst CreateAggregateRet(Value[] retVals) => CreateAggregateRet(retVals.AsSpan());
+
+        public ReturnInst CreateAggregateRet(ReadOnlySpan<Value> retVals)
+        {
+            using var retValHandles = new MarshaledArray<Value, LLVMValueRef>(retVals, (value) => value.Handle);
+            var handle = Handle.BuildAggregateRet(retValHandles);
+            return Context.GetOrCreate<ReturnInst>(handle);
+        }
+
+        public AllocaInst CreateAlloca(Type Ty, Value ArraySize = null, string Name = "") => CreateAlloca(Ty, ArraySize, Name.AsSpan());
+
+        public AllocaInst CreateAlloca(Type Ty, Value ArraySize, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildArrayAlloca(Ty.Handle, ArraySize?.Handle ?? default, Name);
+            return Context.GetOrCreate<AllocaInst>(handle);
+        }
+
+        public Value CreateAnd(Value LHS, Value RHS, string Name = "") => CreateAnd(LHS, RHS, Name.AsSpan());
+
+        public Value CreateAnd(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildAnd(LHS.Handle, RHS.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateAShr(Value LHS, Value RHS, string Name = "") => CreateAShr(LHS, RHS, Name.AsSpan());
+
+        public Value CreateAShr(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildAShr(LHS.Handle, RHS.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public AtomicRMWInst CreateAtomicRMW(AtomicRMWInst.BinOp Op, Value Ptr, Value Val, AtomicOrdering Ordering, SyncScopeID SSID = SyncScopeID.System)
+        {
+            var handle = Handle.BuildAtomicRMW((LLVMAtomicRMWBinOp)Op, Ptr.Handle, Val.Handle, (LLVMAtomicOrdering)Ordering, SSID == SyncScopeID.SingleThread);
+            return Context.GetOrCreate<AtomicRMWInst>(handle);
+        }
+
+        public Value CreateBinOp(Instruction.BinaryOps Opc, Value LHS, Value RHS, string Name = "") => CreateBinOp(Opc, LHS, RHS, Name.AsSpan());
+
+        public Value CreateBinOp(Instruction.BinaryOps Opc, Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildBinOp((LLVMOpcode)Opc, LHS.Handle, RHS.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateBitCast(Value V, Type DestTy, string Name = "") => CreateBitCast(V, DestTy, Name.AsSpan());
+
+        public Value CreateBitCast(Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildBitCast(V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public BranchInst CreateBr(BasicBlock Dest)
+        {
+            var handle = Handle.BuildBr(Dest.Handle);
+            return Context.GetOrCreate<BranchInst>(handle);
+        }
+
+        public CallInst CreateCall(Value Callee, Value[] Args = null, string Name = "") => CreateCall(Callee, Args.AsSpan(), Name.AsSpan());
+
+        public CallInst CreateCall(Value Callee, ReadOnlySpan<Value> Args, ReadOnlySpan<char> Name)
+        {
+            using var argHandles = new MarshaledArray<Value, LLVMValueRef>(Args, (value) => value.Handle);
+            var handle = Handle.BuildCall(Callee.Handle, argHandles, Name);
+            return Context.GetOrCreate<CallInst>(handle);
+        }
+
+        public Value CreateCast(Instruction.CastOps Op, Value V, Type DestTy, string Name = "") => CreateCast(Op, V, DestTy, Name.AsSpan());
+
+        public Value CreateCast(Instruction.CastOps Op, Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildCast((LLVMOpcode)Op, V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public BranchInst CreateCondBr(Value Cond, BasicBlock True, BasicBlock False)
+        {
+            var handle = Handle.BuildCondBr(Cond.Handle, True.Handle, False.Handle);
+            return Context.GetOrCreate<BranchInst>(handle);
+        }
+
+        public Value CreateExactSDiv(Value LHS, Value RHS, string Name = "") => CreateExactSDiv(LHS, RHS, Name.AsSpan());
+
+        public Value CreateExactSDiv(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildExactSDiv(LHS.Handle, RHS.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateExtractElement(Value Vec, Value Idx, string Name = "") => CreateExtractElement(Vec, Idx, Name.AsSpan());
+
+        public Value CreateExtractElement(Value Vec, Value Idx, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildExtractElement(Vec.Handle, Idx.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateExtractValue(Value Agg, uint Idx, string Name = "") => CreateExtractValue(Agg, Idx, Name.AsSpan());
+
+        public Value CreateExtractValue(Value Agg, uint Idx, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildExtractValue(Agg.Handle, Idx, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateFAdd(Value L, Value R, string Name = "") => CreateFAdd(L, R, Name.AsSpan());
+
+        public Value CreateFAdd(Value L, Value R, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildFAdd(L.Handle, R.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateFCmp(CmpInst.Predicate P, Value LHS, Value RHS, string Name = "") => CreateFCmp(P, LHS, RHS, Name.AsSpan());
+
+        public Value CreateFCmp(CmpInst.Predicate P, Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildFCmp((LLVMRealPredicate)P, LHS.Handle, RHS.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateFDiv(Value L, Value R, string Name = "") => CreateFDiv(L, R, Name.AsSpan());
+
+        public Value CreateFDiv(Value L, Value R, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildFDiv(L.Handle, R.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public FenceInst CreateFence(AtomicOrdering Ordering, SyncScopeID SSID = SyncScopeID.System, string Name = "") => CreateFence(Ordering, SSID, Name.AsSpan());
+
+        public FenceInst CreateFence(AtomicOrdering Ordering, SyncScopeID SSID, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildFence((LLVMAtomicOrdering)Ordering, SSID == SyncScopeID.SingleThread, Name);
+            return Context.GetOrCreate<FenceInst>(handle);
+        }
+
+        public Value CreateFMul(Value L, Value R, string Name = "") => CreateFMul(L, R, Name.AsSpan());
+
+        public Value CreateFMul(Value L, Value R, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildFMul(L.Handle, R.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateFNeg(Value V, string Name = "") => CreateFNeg(V, Name.AsSpan());
+
+        public Value CreateFNeg(Value V, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildFNeg(V.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateFPCast(Value V, Type DestTy, string Name = "") => CreateFPCast(V, DestTy, Name.AsSpan());
+
+        public Value CreateFPCast(Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildFPCast(V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateFPExt(Value V, Type DestTy, string Name = "") => CreateFPExt(V, DestTy, Name.AsSpan());
+
+        public Value CreateFPExt(Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildFPExt(V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateFPToSI(Value V, Type DestTy, string Name = "") => CreateFPToSI(V, DestTy, Name.AsSpan());
+
+        public Value CreateFPToSI(Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildFPToSI(V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateFPToUI(Value V, Type DestTy, string Name = "") => CreateFPToUI(V, DestTy, Name.AsSpan());
+
+        public Value CreateFPToUI(Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildFPToUI(V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateFPTrunc(Value V, Type DestTy, string Name = "") => CreateFPTrunc(V, DestTy, Name.AsSpan());
+
+        public Value CreateFPTrunc(Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildFPTrunc(V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateFreeze(Value V, string Name = "") => CreateFreeze(V, Name.AsSpan());
+
+        public Value CreateFreeze(Value V, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildFreeze(V.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateFRem(Value L, Value R, string Name = "") => CreateFRem(L, R, Name.AsSpan());
+
+        public Value CreateFRem(Value L, Value R, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildFRem(L.Handle, R.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateFSub(Value L, Value R, string Name = "") => CreateFSub(L, R, Name.AsSpan());
+
+        public Value CreateFSub(Value L, Value R, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildFSub(L.Handle, R.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateGEP(Value Ptr, Value[] IdxList, string Name = "") => CreateGEP(Ptr, IdxList.AsSpan(), Name.AsSpan());
+
+        public Value CreateGEP(Value Ptr, ReadOnlySpan<Value> IdxList, ReadOnlySpan<char> Name)
+        {
+            using var idxListHandles = new MarshaledArray<Value, LLVMValueRef>(IdxList, (value) => value.Handle);
+            var handle = Handle.BuildGEP(Ptr.Handle, idxListHandles, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Constant CreateGlobalStringPtr(string Str, string Name = "") => CreateGlobalStringPtr(Str.AsSpan(), Name.AsSpan());
+
+        public Constant CreateGlobalStringPtr(ReadOnlySpan<char> Str, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildGlobalStringPtr(Str, Name);
+            return Context.GetOrCreate<Constant>(handle);
+        }
+
+        public Value CreateICmp(CmpInst.Predicate P, Value LHS, Value RHS, string Name = "") => CreateICmp(P, LHS, RHS, Name.AsSpan());
+
+        public Value CreateICmp(CmpInst.Predicate P, Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildICmp((LLVMIntPredicate)P, LHS.Handle, RHS.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateInBoundsGEP(Value Ptr, Value[] IdxList, string Name = "") => CreateInBoundsGEP(Ptr, IdxList.AsSpan(), Name.AsSpan());
+
+        public Value CreateInBoundsGEP(Value Ptr, ReadOnlySpan<Value> IdxList, ReadOnlySpan<char> Name)
+        {
+            using var idxListHandles = new MarshaledArray<Value, LLVMValueRef>(IdxList, (value) => value.Handle);
+            var handle = Handle.BuildInBoundsGEP(Ptr.Handle, idxListHandles, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public IndirectBrInst CreateIndirectBr(Value Addr, uint NumDests = 10)
+        {
+            var handle = Handle.BuildIndirectBr(Addr.Handle, NumDests);
+            return Context.GetOrCreate<IndirectBrInst>(handle);
+        }
+
+        public Value CreateInsertElement(Value Vec, Value NewElt, Value Idx, string Name = "") => CreateInsertElement(Vec, NewElt, Idx, Name.AsSpan());
+
+        public Value CreateInsertElement(Value Vec, Value NewElt, Value Idx, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildInsertElement(Vec.Handle, NewElt.Handle, Idx.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateInsertValue(Value Agg, Value Val, uint Idx, string Name = "") => CreateInsertValue(Agg, Val, Idx, Name.AsSpan());
+
+        public Value CreateInsertValue(Value Agg, Value Val, uint Idx, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildInsertValue(Agg.Handle, Val.Handle, Idx, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateIntCast(Value V, Type DestTy, string Name = "") => CreateIntCast(V, DestTy, Name.AsSpan());
+
+        public Value CreateIntCast(Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildIntCast(V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateIntToPtr(Value V, Type DestTy, string Name = "") => CreateIntToPtr(V, DestTy, Name.AsSpan());
+
+        public Value CreateIntToPtr(Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildIntToPtr(V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public InvokeInst CreateInvoke(Value Callee, BasicBlock NormalDest, BasicBlock UnwindDest, Value[] Args, string Name = "") => CreateInvoke(Callee, NormalDest, UnwindDest, Args.AsSpan(), Name.AsSpan());
+
+        public InvokeInst CreateInvoke(Value Callee, BasicBlock NormalDest, BasicBlock UnwindDest, ReadOnlySpan<Value> Args, ReadOnlySpan<char> Name)
+        {
+            using var argHandles = new MarshaledArray<Value, LLVMValueRef>(Args, (value) => value.Handle);
+            var handle = Handle.BuildInvoke(Callee.Handle, argHandles, NormalDest.Handle, UnwindDest.Handle, Name);
+            return Context.GetOrCreate<InvokeInst>(handle);
+        }
+
+        public Value CreateIsNotNull(Value Arg, string Name = "") => CreateIsNotNull(Arg, Name.AsSpan());
+
+        public Value CreateIsNotNull(Value Arg, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildIsNotNull(Arg.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateIsNull(Value Arg, string Name = "") => CreateIsNull(Arg, Name.AsSpan());
+
+        public Value CreateIsNull(Value Arg, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildIsNull(Arg.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public LandingPadInst CreateLandingPad(Type Ty, uint NumClauses, string Name = "") => CreateLandingPad(Ty, NumClauses, Name.AsSpan());
+
+        public LandingPadInst CreateLandingPad(Type Ty, uint NumClauses, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildLandingPad(Ty.Handle, default, NumClauses, Name);
+            return Context.GetOrCreate<LandingPadInst>(handle);
+        }
+
+        public LoadInst CreateLoad(Value Ptr, string Name = "") => CreateLoad(Ptr, Name.AsSpan());
+
+        public LoadInst CreateLoad(Value Ptr, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildLoad(Ptr.Handle, Name);
+            return Context.GetOrCreate<LoadInst>(handle);
+        }
+
+        public Value CreateLShr(Value LHS, Value RHS, string Name = "") => CreateLShr(LHS, RHS, Name.AsSpan());
+
+        public Value CreateLShr(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildLShr(LHS.Handle, RHS.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateMul(Value LHS, Value RHS, string Name = "") => CreateMul(LHS, RHS, Name.AsSpan());
+
+        public Value CreateMul(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildMul(LHS.Handle, RHS.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateNeg(Value V, string Name = "") => CreateNeg(V, Name.AsSpan());
+
+        public Value CreateNeg(Value V, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildNeg(V.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateNot(Value V, string Name = "") => CreateNot(V, Name.AsSpan());
+
+        public Value CreateNot(Value V, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildNot(V.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateNSWAdd(Value LHS, Value RHS, string Name = "") => CreateNSWAdd(LHS, RHS, Name.AsSpan());
+
+        public Value CreateNSWAdd(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildNSWAdd(LHS.Handle, RHS.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateNSWMul(Value LHS, Value RHS, string Name = "") => CreateNSWMul(LHS, RHS, Name.AsSpan());
+
+        public Value CreateNSWMul(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildNSWMul(LHS.Handle, RHS.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateNSWNeg(Value V, string Name = "") => CreateNSWNeg(V, Name.AsSpan());
+
+        public Value CreateNSWNeg(Value V, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildNSWNeg(V.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateNSWSub(Value LHS, Value RHS, string Name = "") => CreateNSWSub(LHS, RHS, Name.AsSpan());
+
+        public Value CreateNSWSub(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildNSWSub(LHS.Handle, RHS.Handle, Name); ;
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateNUWAdd(Value LHS, Value RHS, string Name = "") => CreateNUWAdd(LHS, RHS, Name.AsSpan());
+
+        public Value CreateNUWAdd(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildNUWAdd(LHS.Handle, RHS.Handle, Name); ;
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateNUWMul(Value LHS, Value RHS, string Name = "") => CreateNUWMul(LHS, RHS, Name.AsSpan());
+
+        public Value CreateNUWMul(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildNUWMul(LHS.Handle, RHS.Handle, Name); ;
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateNUWNeg(Value V, string Name = "") => CreateNUWNeg(V, Name.AsSpan());
+
+        public Value CreateNUWNeg(Value V, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildNUWNeg(V.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateNUWSub(Value LHS, Value RHS, string Name = "") => CreateNUWSub(LHS, RHS, Name.AsSpan());
+
+        public Value CreateNUWSub(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildNUWSub(LHS.Handle, RHS.Handle, Name); ;
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateOr(Value LHS, Value RHS, string Name = "") => CreateOr(LHS, RHS, Name.AsSpan());
+
+        public Value CreateOr(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildOr(LHS.Handle, RHS.Handle, Name); ;
+            return Context.GetOrCreate(handle);
+        }
+
+        public PHINode CreatePHI(Type Ty, string Name = "") => CreatePHI(Ty, Name.AsSpan());
+
+        public PHINode CreatePHI(Type Ty, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildPhi(Ty.Handle, Name);
+            return Context.GetOrCreate<PHINode>(handle);
+        }
+
+        public Value CreatePointerCast(Value V, Type DestTy, string Name = "") => CreatePointerCast(V, DestTy, Name.AsSpan());
+
+        public Value CreatePointerCast(Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildPointerCast(V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreatePtrDiff(Value LHS, Value RHS, string Name = "") => CreatePtrDiff(LHS, RHS, Name.AsSpan());
+
+        public Value CreatePtrDiff(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildPtrDiff(LHS.Handle, RHS.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreatePtrToInt(Value V, Type DestTy, string Name = "") => CreatePtrToInt(V, DestTy, Name.AsSpan());
+
+        public Value CreatePtrToInt(Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildPtrToInt(V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public ResumeInst CreateResume(Value Exn)
+        {
+            var handle = Handle.BuildResume(Exn.Handle);
+            return Context.GetOrCreate<ResumeInst>(handle);
+        }
+
+        public ReturnInst CreateRet(Value V)
+        {
+            var handle = Handle.BuildRet(V.Handle);
+            return Context.GetOrCreate<ReturnInst>(handle);
+        }
+
+        public ReturnInst CreateRetVoid()
+        {
+            var handle = Handle.BuildRetVoid();
+            return Context.GetOrCreate<ReturnInst>(handle);
+        }
+
+        public Value CreateSDiv(Value LHS, Value RHS, string Name = "") => CreateSDiv(LHS, RHS, Name.AsSpan());
+
+        public Value CreateSDiv(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildSDiv(LHS.Handle, RHS.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateSelect(Value C, Value True, Value False, string Name = "") => CreateSelect(C, True, False, Name.AsSpan());
+
+        public Value CreateSelect(Value C, Value True, Value False, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildSelect(C.Handle, True.Handle, False.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateSExt(Value V, Type DestTy, string Name = "") => CreateSExt(V, DestTy, Name.AsSpan());
+
+        public Value CreateSExt(Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildSExt(V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateSExtOrBitCast(Value V, Type DestTy, string Name = "") => CreateSExtOrBitCast(V, DestTy, Name.AsSpan());
+
+        public Value CreateSExtOrBitCast(Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildSExtOrBitCast(V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateShl(Value LHS, Value RHS, string Name = "") => CreateShl(LHS, RHS, Name.AsSpan());
+
+        public Value CreateShl(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildShl(LHS.Handle, RHS.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateShuffleVector(Value V1, Value V2, Value Mask, string Name = "") => CreateShuffleVector(V1, V2, Mask, Name.AsSpan());
+
+        public Value CreateShuffleVector(Value V1, Value V2, Value Mask, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildShuffleVector(V1.Handle, V2.Handle, Mask.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateSIToFP(Value V, Type DestTy, string Name = "") => CreateSIToFP(V, DestTy, Name.AsSpan());
+
+        public Value CreateSIToFP(Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildSIToFP(V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateSRem(Value LHS, Value RHS, string Name = "") => CreateSRem(LHS, RHS, Name.AsSpan());
+
+        public Value CreateSRem(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildSRem(LHS.Handle, RHS.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public StoreInst CreateStore(Value V, Value Ptr)
+        {
+            var handle = Handle.BuildStore(V.Handle, Ptr.Handle);
+            return Context.GetOrCreate<StoreInst>(handle);
+        }
+
+        public Value CreateStructGEP(Value Ptr, uint Idx, string Name = "") => CreateStructGEP(Ptr, Idx, Name.AsSpan());
+
+        public Value CreateStructGEP(Value Ptr, uint Idx, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildStructGEP(Ptr.Handle, Idx, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateSub(Value LHS, Value RHS, string Name = "") => CreateSub(LHS, RHS, Name.AsSpan());
+
+        public Value CreateSub(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildSub(LHS.Handle, RHS.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public SwitchInst CreateSwitch(Value V, BasicBlock Dest, uint NumCases = 10)
+        {
+            var handle = Handle.BuildSwitch(V.Handle, Dest.Handle, NumCases);
+            return Context.GetOrCreate<SwitchInst>(handle);
+        }
+
+        public Value CreateTrunc(Value V, Type DestTy, string Name = "") => CreateTrunc(V, DestTy, Name.AsSpan());
+
+        public Value CreateTrunc(Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildTrunc(V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateTruncOrBitCast(Value V, Type DestTy, string Name = "") => CreateTruncOrBitCast(V, DestTy, Name.AsSpan());
+
+        public Value CreateTruncOrBitCast(Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildTruncOrBitCast(V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateUDiv(Value LHS, Value RHS, string Name = "") => CreateUDiv(LHS, RHS, Name.AsSpan());
+
+        public Value CreateUDiv(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildUDiv(LHS.Handle, RHS.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateUIToFP(Value V, Type DestTy, string Name = "") => CreateUIToFP(V, DestTy, Name.AsSpan());
+
+        public Value CreateUIToFP(Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildUIToFP(V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public UnreachableInst CreateUnreachable()
+        {
+            var handle = Handle.BuildUnreachable();
+            return Context.GetOrCreate<UnreachableInst>(handle);
+        }
+
+        public Value CreateURem(Value LHS, Value RHS, string Name = "") => CreateURem(LHS, RHS, Name.AsSpan());
+
+        public Value CreateURem(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildURem(LHS.Handle, RHS.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public VAArgInst CreateVAArg(Value List, Type Ty, string Name = "") => CreateVAArg(List, Ty, Name.AsSpan());
+
+        public VAArgInst CreateVAArg(Value List, Type Ty, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildVAArg(List.Handle, Ty.Handle, Name);
+            return Context.GetOrCreate<VAArgInst>(handle);
+        }
+
+        public Value CreateXor(Value LHS, Value RHS, string Name = "") => CreateXor(LHS, RHS, Name.AsSpan());
+
+        public Value CreateXor(Value LHS, Value RHS, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildXor(LHS.Handle, RHS.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateZExt(Value V, Type DestTy, string Name = "") => CreateZExt(V, DestTy, Name.AsSpan());
+
+        public Value CreateZExt(Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildZExt(V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Value CreateZExtOrBitCast(Value V, Type DestTy, string Name = "") => CreateZExtOrBitCast(V, DestTy, Name.AsSpan());
+
+        public Value CreateZExtOrBitCast(Value V, Type DestTy, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildZExtOrBitCast(V.Handle, DestTy.Handle, Name);
+            return Context.GetOrCreate(handle);
+        }
+
+        public Instruction Insert(Instruction I, string Name = "") => Insert(I, Name.AsSpan());
+
+        public Instruction Insert(Instruction I, ReadOnlySpan<char> Name)
+        {
+            Handle.InsertWithName(I.Handle, Name);
+            return I;
+        }
+    }
+}

--- a/sources/LLVMSharp/IRBuilderBase.cs
+++ b/sources/LLVMSharp/IRBuilderBase.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using System;
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public unsafe class IRBuilderBase : IEquatable<IRBuilderBase>
+    {
+        private protected IRBuilderBase(LLVMContext C)
+        {
+            Context = C;
+            Handle = LLVMBuilderRef.Create(C.Handle);
+        }
+
+        public LLVMContext Context { get; }
+
+        public LLVMBuilderRef Handle { get; }
+
+        public BasicBlock InsertBlock
+        {
+            get
+            {
+                var handle = Handle.InsertBlock;
+                return Context.GetOrCreate(handle);
+            }
+        }
+
+        public static bool operator ==(IRBuilderBase left, IRBuilderBase right) => (left is object) ? ((right is object) && (left.Handle == right.Handle)) : (right is null);
+
+        public static bool operator !=(IRBuilderBase left, IRBuilderBase right) => (left is object) ? ((right is null) || (left.Handle != right.Handle)) : (right is object);
+
+        public void ClearInsertionPoint() => Handle.ClearInsertionPosition();
+
+        public GlobalVariable CreateGlobalString(string Str, string Name = "") => CreateGlobalString(Str.AsSpan(), Name.AsSpan());
+
+        public GlobalVariable CreateGlobalString(ReadOnlySpan<char> Str, ReadOnlySpan<char> Name)
+        {
+            var handle = Handle.BuildGlobalString(Str, Name);
+            return Context.GetOrCreate<GlobalVariable>(handle);
+        }
+
+        public override bool Equals(object obj) => (obj is IRBuilderBase other) && Equals(other);
+
+        public bool Equals(IRBuilderBase other) => this == other;
+
+        public override int GetHashCode() => Handle.GetHashCode();
+
+        public void SetInsertPoint(BasicBlock TheBB) => Handle.PositionAtEnd(TheBB.Handle);
+
+        public void SetInstDebugLocation(Instruction I) => Handle.SetInstDebugLocation(I.Handle);
+
+        public override string ToString() => Handle.ToString();
+    }
+}

--- a/sources/LLVMSharp/Interop.Extensions/LLVMValueRef.cs
+++ b/sources/LLVMSharp/Interop.Extensions/LLVMValueRef.cs
@@ -960,6 +960,11 @@ namespace LLVMSharp.Interop
 
         public void ReplaceAllUsesWith(LLVMValueRef NewVal) => LLVM.ReplaceAllUsesWith(this, NewVal);
 
+        public void SetAlignment(uint Bytes)
+        {
+            Alignment = Bytes;
+        }
+
         public void SetInstrParamAlignment(uint index, uint align) => LLVM.SetInstrParamAlignment(this, index, align);
 
         public void SetMetadata(uint KindID, LLVMValueRef Node) => LLVM.SetMetadata(this, KindID, Node);

--- a/sources/LLVMSharp/LLVMContext.cs
+++ b/sources/LLVMSharp/LLVMContext.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class LLVMContext : IEquatable<LLVMContext>
+    {
+        private readonly Dictionary<LLVMValueRef, WeakReference<Value>> _createdValues = new Dictionary<LLVMValueRef, WeakReference<Value>>();
+        private readonly Dictionary<LLVMTypeRef, WeakReference<Type>> _createdTypes = new Dictionary<LLVMTypeRef, WeakReference<Type>>();
+
+        public LLVMContext()
+        {
+            Handle = LLVMContextRef.Create();
+        }
+
+        public LLVMContextRef Handle { get; }
+
+        public static bool operator ==(LLVMContext left, LLVMContext right) => (left is object) ? ((right is object) && (left.Handle == right.Handle)) : (right is null);
+
+        public static bool operator !=(LLVMContext left, LLVMContext right) => (left is object) ? ((right is null) || (left.Handle != right.Handle)) : (right is object);
+
+        public override bool Equals(object obj) => (obj is LLVMContext other) && Equals(other);
+
+        public bool Equals(LLVMContext other) => this == other;
+
+        public override int GetHashCode() => Handle.GetHashCode();
+
+        public override string ToString() => Handle.ToString();
+
+        internal BasicBlock GetOrCreate(LLVMBasicBlockRef handle) => GetOrCreate<BasicBlock>(handle.AsValue());
+
+        internal TType GetOrCreate<TType>(LLVMTypeRef handle)
+            where TType : Type
+        {
+            WeakReference<Type> typeRef;
+
+            if (handle == null)
+            {
+                return null;
+            }
+            else if (!_createdTypes.TryGetValue(handle, out typeRef))
+            {
+                typeRef = new WeakReference<Type>(null);
+                _createdTypes.Add(handle, typeRef);
+            }
+
+            if (!typeRef.TryGetTarget(out Type type))
+            {
+                type = Type.Create(handle);
+                typeRef.SetTarget(type);
+            }
+            return (TType)type;
+        }
+
+        internal TValue GetOrCreate<TValue>(LLVMValueRef handle)
+            where TValue : Value
+        {
+            WeakReference<Value> valueRef;
+
+            if (handle == null)
+            {
+                return null;
+            }
+            else if (!_createdValues.TryGetValue(handle, out valueRef))
+            {
+                valueRef = new WeakReference<Value>(null);
+                _createdValues.Add(handle, valueRef);
+            }
+
+            if (!valueRef.TryGetTarget(out Value value))
+            {
+                value = Value.Create(handle);
+                valueRef.SetTarget(value);
+            }
+            return (TValue)value;
+        }
+
+        internal Type GetOrCreate(LLVMTypeRef handle) => GetOrCreate<Type>(handle);
+
+        internal Value GetOrCreate(LLVMValueRef handle) => GetOrCreate<Value>(handle);
+    }
+}

--- a/sources/LLVMSharp/SyncScopeID.cs
+++ b/sources/LLVMSharp/SyncScopeID.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+namespace LLVMSharp
+{
+    public enum SyncScopeID
+    {
+        SingleThread = 0,
+        System = 1,
+    }
+}

--- a/sources/LLVMSharp/Types/ArrayType.cs
+++ b/sources/LLVMSharp/Types/ArrayType.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class ArrayType : SequentialType
+    {
+        internal ArrayType(LLVMTypeRef handle) : base(handle, LLVMTypeKind.LLVMArrayTypeKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Types/CompositeType.cs
+++ b/sources/LLVMSharp/Types/CompositeType.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class CompositeType : Type
+    {
+        private protected CompositeType(LLVMTypeRef handle, LLVMTypeKind expectedTypeKind) : base(handle, expectedTypeKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Types/FunctionType.cs
+++ b/sources/LLVMSharp/Types/FunctionType.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class FunctionType : Type
+    {
+        internal FunctionType(LLVMTypeRef handle) : base(handle, LLVMTypeKind.LLVMFunctionTypeKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Types/IntegerType.cs
+++ b/sources/LLVMSharp/Types/IntegerType.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class IntegerType : Type
+    {
+        internal IntegerType(LLVMTypeRef handle) : base(handle, LLVMTypeKind.LLVMIntegerTypeKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Types/PointerType.cs
+++ b/sources/LLVMSharp/Types/PointerType.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class PointerType : Type
+    {
+        internal PointerType(LLVMTypeRef handle) : base(handle, LLVMTypeKind.LLVMPointerTypeKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Types/SequentialType.cs
+++ b/sources/LLVMSharp/Types/SequentialType.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class SequentialType : CompositeType
+    {
+        private protected SequentialType(LLVMTypeRef handle, LLVMTypeKind expectedTypeKind) : base(handle, expectedTypeKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Types/StructType.cs
+++ b/sources/LLVMSharp/Types/StructType.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class StructType : CompositeType
+    {
+        internal StructType(LLVMTypeRef handle) : base(handle, LLVMTypeKind.LLVMStructTypeKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Types/StructType.cs
+++ b/sources/LLVMSharp/Types/StructType.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
+using System;
 using LLVMSharp.Interop;
 
 namespace LLVMSharp
@@ -8,6 +9,14 @@ namespace LLVMSharp
     {
         internal StructType(LLVMTypeRef handle) : base(handle, LLVMTypeKind.LLVMStructTypeKind)
         {
+        }
+
+        public static StructType Create(LLVMContext Context, string Name) => Create(Context, Name.AsSpan());
+
+        public static StructType Create(LLVMContext Context, ReadOnlySpan<char> Name)
+        {
+            var handle = Context.Handle.CreateNamedStruct(Name);
+            return Context.GetOrCreate<StructType>(handle);
         }
     }
 }

--- a/sources/LLVMSharp/Types/Type.cs
+++ b/sources/LLVMSharp/Types/Type.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using System;
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class Type : IEquatable<Type>
+    {
+        private protected Type(LLVMTypeRef handle, LLVMTypeKind expectedTypeKind)
+        {
+            if (handle.Kind != expectedTypeKind)
+            {
+                throw new ArgumentException(nameof(handle));
+            }
+            Handle = handle;
+        }
+
+        public LLVMTypeRef Handle { get; }
+
+        public static bool operator ==(Type left, Type right) => (left is object) ? ((right is object) && (left.Handle == right.Handle)) : (right is null);
+
+        public static bool operator !=(Type left, Type right) => (left is object) ? ((right is null) || (left.Handle != right.Handle)) : (right is object);
+
+        public override bool Equals(object obj) => (obj is Type other) && Equals(other);
+
+        public bool Equals(Type other) => this == other;
+
+        public override int GetHashCode() => Handle.GetHashCode();
+
+        public override string ToString() => Handle.ToString();
+
+        internal static Type Create(LLVMTypeRef handle) => handle.Kind switch
+        {
+            LLVMTypeKind.LLVMVoidTypeKind => new Type(handle, LLVMTypeKind.LLVMVoidTypeKind),
+            LLVMTypeKind.LLVMHalfTypeKind => new Type(handle, LLVMTypeKind.LLVMHalfTypeKind),
+            LLVMTypeKind.LLVMFloatTypeKind => new Type(handle, LLVMTypeKind.LLVMFloatTypeKind),
+            LLVMTypeKind.LLVMDoubleTypeKind => new Type(handle, LLVMTypeKind.LLVMDoubleTypeKind),
+            LLVMTypeKind.LLVMX86_FP80TypeKind => new Type(handle, LLVMTypeKind.LLVMX86_FP80TypeKind),
+            LLVMTypeKind.LLVMFP128TypeKind => new Type(handle, LLVMTypeKind.LLVMFP128TypeKind),
+            LLVMTypeKind.LLVMPPC_FP128TypeKind => new Type(handle, LLVMTypeKind.LLVMPPC_FP128TypeKind),
+            LLVMTypeKind.LLVMLabelTypeKind => new Type(handle, LLVMTypeKind.LLVMLabelTypeKind),
+            LLVMTypeKind.LLVMIntegerTypeKind => new IntegerType(handle),
+            LLVMTypeKind.LLVMFunctionTypeKind => new FunctionType(handle),
+            LLVMTypeKind.LLVMStructTypeKind => new StructType(handle),
+            LLVMTypeKind.LLVMArrayTypeKind => new ArrayType(handle),
+            LLVMTypeKind.LLVMPointerTypeKind => new PointerType(handle),
+            LLVMTypeKind.LLVMVectorTypeKind => new VectorType(handle),
+            LLVMTypeKind.LLVMMetadataTypeKind => new Type(handle, LLVMTypeKind.LLVMMetadataTypeKind),
+            LLVMTypeKind.LLVMX86_MMXTypeKind => new Type(handle, LLVMTypeKind.LLVMX86_MMXTypeKind),
+            LLVMTypeKind.LLVMTokenTypeKind => new Type(handle, LLVMTypeKind.LLVMTokenTypeKind),
+            _ => new Type(handle, handle.Kind),
+        };
+    }
+}

--- a/sources/LLVMSharp/Types/Type.cs
+++ b/sources/LLVMSharp/Types/Type.cs
@@ -22,6 +22,90 @@ namespace LLVMSharp
 
         public static bool operator !=(Type left, Type right) => (left is object) ? ((right is null) || (left.Handle != right.Handle)) : (right is object);
 
+        public static Type GetDoubleTy(LLVMContext C)
+        {
+            var handle = C.Handle.DoubleType;
+            return C.GetOrCreate(handle);
+        }
+
+        public static Type GetFloatTy(LLVMContext C)
+        {
+            var handle = C.Handle.FloatType;
+            return C.GetOrCreate(handle);
+        }
+
+        public static Type GetHalfTy(LLVMContext C)
+        {
+            var handle = C.Handle.HalfType;
+            return C.GetOrCreate(handle);
+        }
+
+        public static IntegerType GetInt1Ty(LLVMContext C)
+        {
+            var handle = C.Handle.Int1Type;
+            return C.GetOrCreate<IntegerType>(handle);
+        }
+
+        public static IntegerType GetInt8Ty(LLVMContext C)
+        {
+            var handle = C.Handle.Int8Type;
+            return C.GetOrCreate<IntegerType>(handle);
+        }
+
+        public static IntegerType GetInt16Ty(LLVMContext C)
+        {
+            var handle = C.Handle.Int16Type;
+            return C.GetOrCreate<IntegerType>(handle);
+        }
+
+        public static IntegerType GetInt32Ty(LLVMContext C)
+        {
+            var handle = C.Handle.Int32Type;
+            return C.GetOrCreate<IntegerType>(handle);
+        }
+
+        public static IntegerType GetInt64Ty(LLVMContext C)
+        {
+            var handle = C.Handle.Int64Type;
+            return C.GetOrCreate<IntegerType>(handle);
+        }
+
+        public static Type GetFP128Ty(LLVMContext C)
+        {
+            var handle = C.Handle.FP128Type;
+            return C.GetOrCreate(handle);
+        }
+
+        public static Type GetLabelTy(LLVMContext C)
+        {
+            var handle = C.Handle.LabelType;
+            return C.GetOrCreate(handle);
+        }
+
+        public static Type GetPPC_FP128Ty(LLVMContext C)
+        {
+            var handle = C.Handle.PPCFP128Type;
+            return C.GetOrCreate(handle);
+        }
+
+        public static Type GetVoidTy(LLVMContext C)
+        {
+            var handle = C.Handle.VoidType;
+            return C.GetOrCreate(handle);
+        }
+
+        public static Type GetX86_FP80Ty(LLVMContext C)
+        {
+            var handle = C.Handle.X86FP80Type;
+            return C.GetOrCreate(handle);
+        }
+
+        public static Type GetX86_MMXTy(LLVMContext C)
+        {
+            var handle = C.Handle.X86MMXType;
+            return C.GetOrCreate(handle);
+        }
+
         public override bool Equals(object obj) => (obj is Type other) && Equals(other);
 
         public bool Equals(Type other) => this == other;

--- a/sources/LLVMSharp/Types/VectorType.cs
+++ b/sources/LLVMSharp/Types/VectorType.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class VectorType : SequentialType
+    {
+        internal VectorType(LLVMTypeRef handle) : base(handle, LLVMTypeKind.LLVMVectorTypeKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Argument.cs
+++ b/sources/LLVMSharp/Values/Argument.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class Argument : Value
+    {
+        internal Argument(LLVMValueRef handle) : base(handle.IsAArgument, LLVMValueKind.LLVMArgumentValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/BasicBlock.cs
+++ b/sources/LLVMSharp/Values/BasicBlock.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
+using System;
 using LLVMSharp.Interop;
 
 namespace LLVMSharp
@@ -13,6 +14,30 @@ namespace LLVMSharp
         internal BasicBlock(LLVMValueRef handle) : base(handle.IsABasicBlock, LLVMValueKind.LLVMBasicBlockValueKind)
         {
             Handle = handle.AsBasicBlock();
+        }
+
+        public static BasicBlock Create(LLVMContext Context, string Name) => Create(Context, Name.AsSpan());
+
+        public static BasicBlock Create(LLVMContext Context, ReadOnlySpan<char> Name)
+        {
+            var handle = LLVMBasicBlockRef.CreateInContext(Context.Handle, Name);
+            return new BasicBlock(handle);
+        }
+
+        public static BasicBlock Create(LLVMContext Context, string Name, Function Parent) => Create(Context, Name.AsSpan(), Parent);
+
+        public static BasicBlock Create(LLVMContext Context, ReadOnlySpan<char> Name, Function Parent)
+        {
+            var handle = LLVMBasicBlockRef.AppendInContext(Context.Handle, Parent.Handle, Name);
+            return new BasicBlock(handle);
+        }
+
+        public static BasicBlock Create(LLVMContext Context, string Name, BasicBlock InsertBefore) => Create(Context, Name.AsSpan(), InsertBefore);
+
+        public static BasicBlock Create(LLVMContext Context, ReadOnlySpan<char> Name, BasicBlock InsertBefore)
+        {
+            var handle = LLVMBasicBlockRef.InsertInContext(Context.Handle, InsertBefore.Handle, Name);
+            return new BasicBlock(handle);
         }
 
         public new LLVMBasicBlockRef Handle { get; }

--- a/sources/LLVMSharp/Values/BasicBlock.cs
+++ b/sources/LLVMSharp/Values/BasicBlock.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class BasicBlock : Value
+    {
+        private BasicBlock(LLVMBasicBlockRef handle) : this(handle.AsValue())
+        {
+        }
+
+        internal BasicBlock(LLVMValueRef handle) : base(handle.IsABasicBlock, LLVMValueKind.LLVMBasicBlockValueKind)
+        {
+            Handle = handle.AsBasicBlock();
+        }
+
+        public new LLVMBasicBlockRef Handle { get; }
+
+        public LLVMValueRef ValueHandle => base.Handle;
+    }
+}

--- a/sources/LLVMSharp/Values/InlineAsm.cs
+++ b/sources/LLVMSharp/Values/InlineAsm.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class InlineAsm : Value
+    {
+        internal InlineAsm(LLVMValueRef handle) : base(handle.IsAInlineAsm, LLVMValueKind.LLVMInlineAsmValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/MetadataAsValue.cs
+++ b/sources/LLVMSharp/Values/MetadataAsValue.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class MetadataAsValue : Value
+    {
+        internal MetadataAsValue(LLVMValueRef handle) : base(handle, LLVMValueKind.LLVMMetadataAsValueValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/BlockAddress.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/BlockAddress.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class BlockAddress : Constant
+    {
+        internal BlockAddress(LLVMValueRef handle) : base(handle.IsABlockAddress, LLVMValueKind.LLVMBlockAddressValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/Constant.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/Constant.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class Constant : User
+    {
+        private protected Constant(LLVMValueRef handle, LLVMValueKind expectedValueKind) : base(handle.IsAConstant, expectedValueKind)
+        {
+        }
+
+        internal new static Constant Create(LLVMValueRef handle) => handle switch
+        {
+            _ when handle.IsABlockAddress != null => new BlockAddress(handle),
+            _ when handle.IsAConstantAggregateZero != null => new ConstantAggregateZero(handle),
+            _ when handle.IsAConstantArray != null => new ConstantArray(handle),
+            _ when handle.IsAConstantDataSequential != null => ConstantDataSequential.Create(handle),
+            _ when handle.IsAConstantExpr != null => ConstantExpr.Create(handle),
+            _ when handle.IsAConstantFP != null => new ConstantFP(handle),
+            _ when handle.IsAConstantInt != null => new ConstantInt(handle),
+            _ when handle.IsAConstantPointerNull != null => new ConstantPointerNull(handle),
+            _ when handle.IsAConstantStruct != null => new ConstantStruct(handle),
+            _ when handle.IsAConstantTokenNone != null => new ConstantTokenNone(handle),
+            _ when handle.IsAConstantVector != null => new ConstantVector(handle),
+            _ when handle.IsAGlobalValue != null => GlobalValue.Create(handle),
+            _ when handle.IsAUndefValue != null => new UndefValue(handle),
+            _ => new Constant(handle, handle.Kind),
+        };
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantAggregates/ConstantAggregate.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantAggregates/ConstantAggregate.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class ConstantAggregate : Constant
+    {
+        private protected ConstantAggregate(LLVMValueRef handle, LLVMValueKind expectedValueKind) : base(handle, expectedValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantAggregates/ConstantArray.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantAggregates/ConstantArray.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class ConstantArray : ConstantAggregate
+    {
+        internal ConstantArray(LLVMValueRef handle) : base(handle.IsAConstantArray, LLVMValueKind.LLVMConstantArrayValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantAggregates/ConstantStruct.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantAggregates/ConstantStruct.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using System;
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class ConstantStruct : ConstantAggregate
+    {
+        internal ConstantStruct(LLVMValueRef handle) : base(handle.IsAConstantStruct, LLVMValueKind.LLVMConstantStructValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantAggregates/ConstantStruct.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantAggregates/ConstantStruct.cs
@@ -10,5 +10,14 @@ namespace LLVMSharp
         internal ConstantStruct(LLVMValueRef handle) : base(handle.IsAConstantStruct, LLVMValueKind.LLVMConstantStructValueKind)
         {
         }
+
+        public static Constant GetAnon(LLVMContext Ctx, Constant[] V, bool Packed = false) => GetAnon(Ctx, V.AsSpan(), Packed);
+
+        public static Constant GetAnon(LLVMContext Ctx, ReadOnlySpan<Constant> V, bool Packed)
+        {
+            using var marshaledV = new MarshaledArray<Constant, LLVMValueRef>(V, (value) => value.Handle);
+            var handle = Ctx.Handle.GetConstStruct(marshaledV, Packed);
+            return Ctx.GetOrCreate<Constant>(handle);
+        }
     }
 }

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantAggregates/ConstantVector.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantAggregates/ConstantVector.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class ConstantVector : ConstantAggregate
+    {
+        internal ConstantVector(LLVMValueRef handle) : base(handle.IsAConstantVector, LLVMValueKind.LLVMConstantVectorValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantAggregateZero.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantAggregateZero.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class ConstantAggregateZero : ConstantData
+    {
+        internal ConstantAggregateZero(LLVMValueRef handle) : base(handle.IsAConstantAggregateZero, LLVMValueKind.LLVMConstantAggregateZeroValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantData.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantData.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class ConstantData : Constant
+    {
+        private protected ConstantData(LLVMValueRef handle, LLVMValueKind expectedValueKind) : base(handle, expectedValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantDataArray.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantDataArray.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using System;
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class ConstantDataArray : ConstantDataSequential
+    {
+        internal ConstantDataArray(LLVMValueRef handle) : base(handle.IsAConstantDataArray, LLVMValueKind.LLVMConstantDataArrayValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantDataArray.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantDataArray.cs
@@ -10,5 +10,13 @@ namespace LLVMSharp
         internal ConstantDataArray(LLVMValueRef handle) : base(handle.IsAConstantDataArray, LLVMValueKind.LLVMConstantDataArrayValueKind)
         {
         }
+
+        public static Constant GetString(LLVMContext Context, string Initializer, bool AddNull = true) => GetString(Context, Initializer.AsSpan(), AddNull);
+
+        public static Constant GetString(LLVMContext Context, ReadOnlySpan<char> Initializer, bool AddNull)
+        {
+            var handle = Context.Handle.GetConstString(Initializer, !AddNull);
+            return Context.GetOrCreate<Constant>(handle);
+        }
     }
 }

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantDataSequential.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantDataSequential.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class ConstantDataSequential : ConstantData
+    {
+        private protected ConstantDataSequential(LLVMValueRef handle, LLVMValueKind expectedValueKind) : base(handle.IsAConstantDataSequential, expectedValueKind)
+        {
+        }
+
+        internal new static ConstantDataSequential Create(LLVMValueRef handle) => handle switch
+        {
+            _ when handle.IsAConstantDataArray != null => new ConstantDataArray(handle),
+            _ when handle.IsAConstantDataVector != null => new ConstantDataVector(handle),
+            _ => new ConstantDataSequential(handle, handle.Kind),
+        };
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantDataVector.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantDataVector.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class ConstantDataVector : ConstantDataSequential
+    {
+        internal ConstantDataVector(LLVMValueRef handle) : base(handle.IsAConstantDataVector, LLVMValueKind.LLVMConstantDataVectorValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantFP.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantFP.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class ConstantFP : ConstantData
+    {
+        internal ConstantFP(LLVMValueRef handle) : base(handle.IsAConstantFP, LLVMValueKind.LLVMConstantFPValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantInt.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantInt.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class ConstantInt : ConstantData
+    {
+        internal ConstantInt(LLVMValueRef handle) : base(handle.IsAConstantInt, LLVMValueKind.LLVMConstantIntValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantPointerNull.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantPointerNull.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class ConstantPointerNull : ConstantData
+    {
+        internal ConstantPointerNull(LLVMValueRef handle) : base(handle.IsAConstantPointerNull, LLVMValueKind.LLVMConstantPointerNullValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantTokenNone.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantTokenNone.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class ConstantTokenNone : ConstantData
+    {
+        internal ConstantTokenNone(LLVMValueRef handle) : base(handle.IsAConstantTokenNone, LLVMValueKind.LLVMConstantTokenNoneValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/UndefValue.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/UndefValue.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class UndefValue : ConstantData
+    {
+        internal UndefValue(LLVMValueRef handle) : base(handle.IsAUndefValue, LLVMValueKind.LLVMUndefValueValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantExprs/ConstantExpr.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantExprs/ConstantExpr.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class ConstantExpr : Constant
+    {
+        private protected ConstantExpr(LLVMValueRef handle) : base(handle.IsAConstantExpr, LLVMValueKind.LLVMConstantExprValueKind)
+        {
+        }
+
+        internal static new ConstantExpr Create(LLVMValueRef handle) => handle switch
+        {
+            _ => new ConstantExpr(handle),
+        };
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/GlobalValues/Function.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/GlobalValues/Function.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class Function : GlobalObject
+    {
+        internal Function(LLVMValueRef handle) : base(handle.IsAFunction, LLVMValueKind.LLVMFunctionValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalAlias.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalAlias.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class GlobalAlias : GlobalIndirectSymbol
+    {
+        internal GlobalAlias(LLVMValueRef handle) : base(handle.IsAGlobalAlias, LLVMValueKind.LLVMGlobalAliasValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalIFunc.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalIFunc.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class GlobalIFunc : GlobalIndirectSymbol
+    {
+        internal GlobalIFunc(LLVMValueRef handle) : base(handle.IsAGlobalIFunc, LLVMValueKind.LLVMGlobalIFuncValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalIndirectSymbol.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalIndirectSymbol.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class GlobalIndirectSymbol : GlobalValue
+    {
+        private protected GlobalIndirectSymbol(LLVMValueRef handle, LLVMValueKind expectedValueKind) : base(handle, expectedValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalObject.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalObject.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class GlobalObject : GlobalValue
+    {
+        private protected GlobalObject(LLVMValueRef handle, LLVMValueKind expectedValueKind) : base(handle.IsAGlobalObject, expectedValueKind)
+        {
+        }
+
+        internal new static GlobalObject Create(LLVMValueRef handle) => handle switch
+        {
+            _ when handle.IsAFunction != null => new Function(handle),
+            _ when handle.IsAGlobalVariable != null => new GlobalVariable(handle),
+            _ => new GlobalObject(handle, handle.Kind),
+        };
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalValue.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalValue.cs
@@ -4,7 +4,7 @@ using LLVMSharp.Interop;
 
 namespace LLVMSharp
 {
-    public unsafe class GlobalValue : Constant
+    public class GlobalValue : Constant
     {
         private protected GlobalValue(LLVMValueRef handle, LLVMValueKind expectedValueKind) : base(handle.IsAGlobalValue, expectedValueKind)
         {

--- a/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalValue.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalValue.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public unsafe class GlobalValue : Constant
+    {
+        private protected GlobalValue(LLVMValueRef handle, LLVMValueKind expectedValueKind) : base(handle.IsAGlobalValue, expectedValueKind)
+        {
+        }
+
+        public uint Alignment
+        {
+            get => Handle.Alignment;
+            set => Handle.SetAlignment(value);
+        }
+
+        internal new static GlobalValue Create(LLVMValueRef handle) => handle switch
+        {
+            _ when handle.IsAGlobalAlias != null => new GlobalAlias(handle),
+            _ when handle.IsAGlobalIFunc != null => new GlobalIFunc(handle),
+            _ when handle.IsAGlobalObject != null => GlobalObject.Create(handle),
+            _ => new GlobalValue(handle, handle.Kind),
+        };
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalVariable.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalVariable.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class GlobalVariable : GlobalObject
+    {
+        internal GlobalVariable(LLVMValueRef handle) : base(handle.IsAGlobalVariable, LLVMValueKind.LLVMGlobalVariableValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/DerivedUsers/DerivedUser.cs
+++ b/sources/LLVMSharp/Values/Users/DerivedUsers/DerivedUser.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class DerivedUser : User
+    {
+        private protected DerivedUser(LLVMValueRef handle, LLVMValueKind expectedValueKind) : base(handle, expectedValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/DerivedUsers/MemoryAccess.cs
+++ b/sources/LLVMSharp/Values/Users/DerivedUsers/MemoryAccess.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class MemoryAccess : DerivedUser
+    {
+        private protected MemoryAccess(LLVMValueRef handle, LLVMValueKind expectedValueKind) : base(handle, expectedValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/DerivedUsers/MemoryDef.cs
+++ b/sources/LLVMSharp/Values/Users/DerivedUsers/MemoryDef.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class MemoryDef : MemoryUseOrDef
+    {
+        internal MemoryDef(LLVMValueRef handle) : base(handle, LLVMValueKind.LLVMMemoryDefValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/DerivedUsers/MemoryPhi.cs
+++ b/sources/LLVMSharp/Values/Users/DerivedUsers/MemoryPhi.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class MemoryPhi : MemoryAccess
+    {
+        internal MemoryPhi(LLVMValueRef handle) : base(handle, LLVMValueKind.LLVMMemoryPhiValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/DerivedUsers/MemoryUse.cs
+++ b/sources/LLVMSharp/Values/Users/DerivedUsers/MemoryUse.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class MemoryUse : MemoryUseOrDef
+    {
+        internal MemoryUse(LLVMValueRef handle) : base(handle, LLVMValueKind.LLVMMemoryUseValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/DerivedUsers/MemoryUseOrDef.cs
+++ b/sources/LLVMSharp/Values/Users/DerivedUsers/MemoryUseOrDef.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class MemoryUseOrDef : MemoryAccess
+    {
+        private protected MemoryUseOrDef(LLVMValueRef handle, LLVMValueKind expectedValueKind) : base(handle, expectedValueKind)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/AddrSpaceCastInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/AddrSpaceCastInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class AddrSpaceCastInst : CastInst
+    {
+        internal AddrSpaceCastInst(LLVMValueRef handle) : base(handle.IsAAddrSpaceCastInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/AllocaInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/AllocaInst.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class AllocaInst : UnaryInstruction
+    {
+        internal AllocaInst(LLVMValueRef handle) : base(handle.IsAAllocaInst)
+        {
+        }
+
+        public uint Alignment
+        {
+            get => Handle.Alignment;
+            set => Handle.SetAlignment(value);
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/AtomicCmpXchgInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/AtomicCmpXchgInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class AtomicCmpXchgInst : Instruction
+    {
+        internal AtomicCmpXchgInst(LLVMValueRef handle) : base(handle.IsAAtomicCmpXchgInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/AtomicRMWInst.BinOp.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/AtomicRMWInst.BinOp.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public partial class AtomicRMWInst
+    {
+        public enum BinOp
+        {
+            Xchg = LLVMAtomicRMWBinOp.LLVMAtomicRMWBinOpXchg,
+            Add = LLVMAtomicRMWBinOp.LLVMAtomicRMWBinOpAdd,
+            Sub = LLVMAtomicRMWBinOp.LLVMAtomicRMWBinOpSub,
+            And = LLVMAtomicRMWBinOp.LLVMAtomicRMWBinOpAnd,
+            Nand = LLVMAtomicRMWBinOp.LLVMAtomicRMWBinOpNand,
+            Or = LLVMAtomicRMWBinOp.LLVMAtomicRMWBinOpOr,
+            Xor = LLVMAtomicRMWBinOp.LLVMAtomicRMWBinOpXor,
+            Max = LLVMAtomicRMWBinOp.LLVMAtomicRMWBinOpMax,
+            Min = LLVMAtomicRMWBinOp.LLVMAtomicRMWBinOpMin,
+            UMax = LLVMAtomicRMWBinOp.LLVMAtomicRMWBinOpUMax,
+            UMin = LLVMAtomicRMWBinOp.LLVMAtomicRMWBinOpUMin,
+            FAdd = LLVMAtomicRMWBinOp.LLVMAtomicRMWBinOpFAdd,
+            FSub = LLVMAtomicRMWBinOp.LLVMAtomicRMWBinOpFSub,
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/AtomicRMWInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/AtomicRMWInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed partial class AtomicRMWInst : Instruction
+    {
+        internal AtomicRMWInst(LLVMValueRef handle) : base(handle.IsAAtomicRMWInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/BinaryOperator.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/BinaryOperator.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class BinaryOperator : Instruction
+    {
+        internal BinaryOperator(LLVMValueRef handle) : base(handle.IsABinaryOperator)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/BitCastInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/BitCastInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class BitCastInst : CastInst
+    {
+        internal BitCastInst(LLVMValueRef handle) : base(handle.IsABitCastInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/BranchInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/BranchInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class BranchInst : Instruction
+    {
+        internal BranchInst(LLVMValueRef handle) : base(handle.IsABranchInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/CallBase.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/CallBase.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class CallBase : Instruction
+    {
+        private protected CallBase(LLVMValueRef handle) : base(handle)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/CallBrInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/CallBrInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class CallBrInst : CallBase
+    {
+        internal CallBrInst(LLVMValueRef handle) : base(handle.IsACallBrInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/CallInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/CallInst.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class CallInst : CallBase
+    {
+        private protected CallInst(LLVMValueRef handle) : base(handle.IsACallInst)
+        {
+        }
+
+        internal static new CallInst Create(LLVMValueRef handle) => handle switch
+        {
+            _ when handle.IsAIntrinsicInst != null => IntrinsicInst.Create(handle),
+            _ => new CallInst(handle),
+        };
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/CastInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/CastInst.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class CastInst : UnaryInstruction
+    {
+        private protected CastInst(LLVMValueRef handle) : base(handle.IsACastInst)
+        {
+        }
+
+        internal static new CastInst Create(LLVMValueRef handle) => handle switch
+        {
+            _ when handle.IsAAddrSpaceCastInst != null => new AddrSpaceCastInst(handle),
+            _ when handle.IsABitCastInst != null => new BitCastInst(handle),
+            _ when handle.IsAFPExtInst != null => new FPExtInst(handle),
+            _ when handle.IsAFPToSIInst != null => new FPToSIInst(handle),
+            _ when handle.IsAFPToUIInst != null => new FPToUIInst(handle),
+            _ when handle.IsAFPTruncInst != null => new FPTruncInst(handle),
+            _ when handle.IsAIntToPtrInst != null => new IntToPtrInst(handle),
+            _ when handle.IsAPtrToIntInst != null => new PtrToIntInst(handle),
+            _ when handle.IsASExtInst != null => new SExtInst(handle),
+            _ when handle.IsASIToFPInst != null => new SIToFPInst(handle),
+            _ when handle.IsATruncInst != null => new TruncInst(handle),
+            _ when handle.IsAUIToFPInst != null => new UIToFPInst(handle),
+            _ when handle.IsAZExtInst != null => new ZExtInst(handle),
+            _ => new CastInst(handle),
+        };
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/CatchPadInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/CatchPadInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class CatchPadInst : FuncletPadInst
+    {
+        internal CatchPadInst(LLVMValueRef handle) : base(handle.IsACatchPadInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/CatchReturnInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/CatchReturnInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class CatchReturnInst : Instruction
+    {
+        internal CatchReturnInst(LLVMValueRef handle) : base(handle.IsACatchReturnInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/CatchSwitchInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/CatchSwitchInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class CatchSwitchInst : Instruction
+    {
+        internal CatchSwitchInst(LLVMValueRef handle) : base(handle.IsACatchSwitchInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/CleanupPadInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/CleanupPadInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class CleanupPadInst : FuncletPadInst
+    {
+        internal CleanupPadInst(LLVMValueRef handle) : base(handle.IsACleanupPadInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/CleanupReturnInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/CleanupReturnInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class CleanupReturnInst : Instruction
+    {
+        internal CleanupReturnInst(LLVMValueRef handle) : base(handle.IsACleanupReturnInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/CmpInst.Predicate.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/CmpInst.Predicate.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public partial class CmpInst
+    {
+        public enum Predicate
+        {
+            FCMP_FALSE = LLVMRealPredicate.LLVMRealPredicateFalse,
+            FCMP_OEQ = LLVMRealPredicate.LLVMRealOEQ,
+            FCMP_OGT = LLVMRealPredicate.LLVMRealOGT,
+            FCMP_OGE = LLVMRealPredicate.LLVMRealOGE,
+            FCMP_OLT = LLVMRealPredicate.LLVMRealOLT,
+            FCMP_OLE = LLVMRealPredicate.LLVMRealOLE,
+            FCMP_ONE = LLVMRealPredicate.LLVMRealONE,
+            FCMP_ORD = LLVMRealPredicate.LLVMRealORD,
+            FCMP_UNO = LLVMRealPredicate.LLVMRealUNO,
+            FCMP_UEQ = LLVMRealPredicate.LLVMRealUEQ,
+            FCMP_UGT = LLVMRealPredicate.LLVMRealUGT,
+            FCMP_UGE = LLVMRealPredicate.LLVMRealUGE,
+            FCMP_ULT = LLVMRealPredicate.LLVMRealULT,
+            FCMP_ULE = LLVMRealPredicate.LLVMRealULE,
+            FCMP_UNE = LLVMRealPredicate.LLVMRealUNE,
+            FCMP_TRUE = LLVMRealPredicate.LLVMRealPredicateTrue,
+
+            ICMP_EQ = LLVMIntPredicate.LLVMIntEQ,
+            ICMP_NE = LLVMIntPredicate.LLVMIntNE,
+            ICMP_UGT = LLVMIntPredicate.LLVMIntUGT,
+            ICMP_UGE = LLVMIntPredicate.LLVMIntUGE,
+            ICMP_ULT = LLVMIntPredicate.LLVMIntULT,
+            ICMP_ULE = LLVMIntPredicate.LLVMIntULE,
+            ICMP_SGT = LLVMIntPredicate.LLVMIntSGT,
+            ICMP_SGE = LLVMIntPredicate.LLVMIntSGE,
+            ICMP_SLT = LLVMIntPredicate.LLVMIntSLT,
+            ICMP_SLE = LLVMIntPredicate.LLVMIntSLE,
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/CmpInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/CmpInst.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public partial class CmpInst : Instruction
+    {
+        private protected CmpInst(LLVMValueRef handle) : base(handle.IsACmpInst)
+        {
+        }
+
+        internal static new CmpInst Create(LLVMValueRef handle) => handle switch
+        {
+            _ when handle.IsAFCmpInst != null => new FCmpInst(handle),
+            _ when handle.IsAICmpInst != null => new ICmpInst(handle),
+            _ => new CmpInst(handle),
+        };
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/DbgDeclareInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/DbgDeclareInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class DbgDeclareInst : DbgVariableIntrinsic
+    {
+        internal DbgDeclareInst(LLVMValueRef handle) : base(handle.IsADbgDeclareInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/DbgInfoIntrinsic.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/DbgInfoIntrinsic.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class DbgInfoIntrinsic : IntrinsicInst
+    {
+        private protected DbgInfoIntrinsic(LLVMValueRef handle) : base(handle.IsADbgInfoIntrinsic)
+        {
+        }
+
+        internal static new DbgInfoIntrinsic Create(LLVMValueRef handle) => handle switch
+        {
+            _ when handle.IsADbgVariableIntrinsic != null => DbgVariableIntrinsic.Create(handle),
+            _ when handle.IsADbgLabelInst != null => new DbgLabelInst(handle),
+            _ => new DbgInfoIntrinsic(handle),
+        };
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/DbgLabelInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/DbgLabelInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class DbgLabelInst : DbgInfoIntrinsic
+    {
+        internal DbgLabelInst(LLVMValueRef handle) : base(handle.IsADbgLabelInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/DbgVariableIntrinsic.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/DbgVariableIntrinsic.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class DbgVariableIntrinsic : DbgInfoIntrinsic
+    {
+        private protected DbgVariableIntrinsic(LLVMValueRef handle) : base(handle.IsADbgVariableIntrinsic)
+        {
+        }
+
+        internal static new DbgVariableIntrinsic Create(LLVMValueRef handle) => handle switch
+        {
+            _ when handle.IsADbgDeclareInst != null => new DbgDeclareInst(handle),
+            _ => new DbgVariableIntrinsic(handle),
+        };
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/ExtractElementInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/ExtractElementInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class ExtractElementInst : Instruction
+    {
+        internal ExtractElementInst(LLVMValueRef handle) : base(handle.IsAExtractElementInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/ExtractValueInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/ExtractValueInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class ExtractValueInst : UnaryInstruction
+    {
+        internal ExtractValueInst(LLVMValueRef handle) : base(handle.IsAExtractValueInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/FCmpInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/FCmpInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class FCmpInst : CmpInst
+    {
+        internal FCmpInst(LLVMValueRef handle) : base(handle.IsAFCmpInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/FPExtInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/FPExtInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class FPExtInst : CastInst
+    {
+        internal FPExtInst(LLVMValueRef handle) : base(handle.IsAFPExtInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/FPToSIInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/FPToSIInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class FPToSIInst : CastInst
+    {
+        internal FPToSIInst(LLVMValueRef handle) : base(handle.IsAFPToSIInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/FPToUIInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/FPToUIInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class FPToUIInst : CastInst
+    {
+        internal FPToUIInst(LLVMValueRef handle) : base(handle.IsAFPToUIInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/FPTruncInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/FPTruncInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class FPTruncInst : CastInst
+    {
+        internal FPTruncInst(LLVMValueRef handle) : base(handle.IsAFPTruncInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/FenceInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/FenceInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class FenceInst : Instruction
+    {
+        internal FenceInst(LLVMValueRef handle) : base(handle.IsAFenceInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/FreezeInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/FreezeInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class FreezeInst : UnaryInstruction
+    {
+        internal FreezeInst(LLVMValueRef handle) : base(handle.IsAFreezeInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/FuncletPadInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/FuncletPadInst.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class FuncletPadInst : Instruction
+    {
+        private protected FuncletPadInst(LLVMValueRef handle) : base(handle.IsAFuncletPadInst)
+        {
+        }
+
+        internal static new FuncletPadInst Create(LLVMValueRef handle) => handle switch
+        {
+            _ when handle.IsACatchPadInst != null => new CatchPadInst(handle),
+            _ when handle.IsACleanupPadInst != null => new CleanupPadInst(handle),
+            _ => new FuncletPadInst(handle),
+        };
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/GetElementPtrInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/GetElementPtrInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class GetElementPtrInst : Instruction
+    {
+        internal GetElementPtrInst(LLVMValueRef handle) : base(handle.IsAGetElementPtrInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/ICmpInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/ICmpInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class ICmpInst : CmpInst
+    {
+        internal ICmpInst(LLVMValueRef handle) : base(handle.IsAICmpInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/IndirectBrInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/IndirectBrInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class IndirectBrInst : Instruction
+    {
+        internal IndirectBrInst(LLVMValueRef handle) : base(handle.IsAIndirectBrInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/InsertElementInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/InsertElementInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class InsertElementInst : Instruction
+    {
+        internal InsertElementInst(LLVMValueRef handle) : base(handle.IsAInsertElementInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/InsertValueInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/InsertValueInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class InsertValueInst : Instruction
+    {
+        internal InsertValueInst(LLVMValueRef handle) : base(handle.IsAInsertValueInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/Instruction.BinaryOps.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/Instruction.BinaryOps.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public partial class Instruction
+    {
+        public enum BinaryOps
+        {
+            Add = LLVMOpcode.LLVMAdd,
+            FAdd = LLVMOpcode.LLVMFAdd,
+            Sub = LLVMOpcode.LLVMSub,
+            FSub = LLVMOpcode.LLVMFSub,
+            Mul = LLVMOpcode.LLVMMul,
+            FMul = LLVMOpcode.LLVMFMul,
+            UDiv = LLVMOpcode.LLVMUDiv,
+            SDiv = LLVMOpcode.LLVMSDiv,
+            FDiv = LLVMOpcode.LLVMFDiv,
+            URem = LLVMOpcode.LLVMURem,
+            SRem = LLVMOpcode.LLVMSRem,
+            FRem = LLVMOpcode.LLVMFRem,
+            Shl = LLVMOpcode.LLVMShl,
+            LShr = LLVMOpcode.LLVMLShr,
+            AShr = LLVMOpcode.LLVMAShr,
+            And = LLVMOpcode.LLVMAnd,
+            Or = LLVMOpcode.LLVMOr,
+            Xor = LLVMOpcode.LLVMXor,
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/Instruction.CastOps.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/Instruction.CastOps.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public partial class Instruction
+    {
+        public enum CastOps
+        {
+            Trunc = LLVMOpcode.LLVMTrunc,
+            ZExt = LLVMOpcode.LLVMZExt,
+            SExt = LLVMOpcode.LLVMSExt,
+            FPToUI = LLVMOpcode.LLVMFPToUI,
+            FPToSI = LLVMOpcode.LLVMFPToSI,
+            UIToFP = LLVMOpcode.LLVMUIToFP,
+            SIToFP = LLVMOpcode.LLVMSIToFP,
+            FPTrunc = LLVMOpcode.LLVMFPTrunc,
+            FPExt = LLVMOpcode.LLVMFPExt,
+            PtrToInt = LLVMOpcode.LLVMPtrToInt,
+            IntToPtr = LLVMOpcode.LLVMIntToPtr,
+            BitCast = LLVMOpcode.LLVMBitCast,
+            AddrSpaceCast = LLVMOpcode.LLVMAddrSpaceCast,
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/Instruction.FuncletPadOps.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/Instruction.FuncletPadOps.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public partial class Instruction
+    {
+        public enum FuncletPadOps
+        {
+            CleanupPad = LLVMOpcode.LLVMCleanupPad,
+            CatchPad = LLVMOpcode.LLVMCatchPad,
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/Instruction.MemoryOps.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/Instruction.MemoryOps.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public partial class Instruction
+    {
+        public enum MemoryOps
+        {
+            Alloca = LLVMOpcode.LLVMAlloca,
+            Load = LLVMOpcode.LLVMLoad,
+            Store = LLVMOpcode.LLVMStore,
+            GetElementPtr = LLVMOpcode.LLVMGetElementPtr,
+            Fence = LLVMOpcode.LLVMFence,
+            AtomicCmpXchg = LLVMOpcode.LLVMAtomicCmpXchg,
+            AtomicRMW = LLVMOpcode.LLVMAtomicRMW,
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/Instruction.OtherOps.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/Instruction.OtherOps.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public partial class Instruction
+    {
+        public enum OtherOps
+        {
+            ICmp  = LLVMOpcode.LLVMICmp,
+            FCmp = LLVMOpcode.LLVMFCmp,
+            PHI = LLVMOpcode.LLVMPHI,
+            Call = LLVMOpcode.LLVMCall,
+            Select = LLVMOpcode.LLVMSelect,
+            UserOp1 = LLVMOpcode.LLVMUserOp1,
+            UserOp2 = LLVMOpcode.LLVMUserOp2,
+            VAArg = LLVMOpcode.LLVMVAArg,
+            ExtractElement = LLVMOpcode.LLVMExtractElement,
+            InsertElement = LLVMOpcode.LLVMInsertElement,
+            ShuffleVector = LLVMOpcode.LLVMShuffleVector,
+            ExtractValue = LLVMOpcode.LLVMExtractValue,
+            InsertValue = LLVMOpcode.LLVMInsertValue,
+            LandingPad = LLVMOpcode.LLVMLandingPad,
+            Freeze = LLVMOpcode.LLVMFreeze,
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/Instruction.TermOps.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/Instruction.TermOps.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public partial class Instruction
+    {
+        public enum TermOps
+        {
+            Ret = LLVMOpcode.LLVMRet,
+            Br = LLVMOpcode.LLVMBr,
+            Switch = LLVMOpcode.LLVMSwitch,
+            IndirectBr = LLVMOpcode.LLVMIndirectBr,
+            Invoke = LLVMOpcode.LLVMInvoke,
+            Resume = LLVMOpcode.LLVMResume,
+            Unreachable = LLVMOpcode.LLVMUnreachable,
+            CleanupRet = LLVMOpcode.LLVMCleanupRet,
+            CatchRet = LLVMOpcode.LLVMCatchRet,
+            CatchSwitch = LLVMOpcode.LLVMCatchSwitch,
+            CallBr = LLVMOpcode.LLVMCallBr,
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/Instruction.UnaryOps.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/Instruction.UnaryOps.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public partial class Instruction
+    {
+        public enum UnaryOps
+        {
+            FNeg = LLVMOpcode.LLVMFNeg,
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/Instruction.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/Instruction.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public partial class Instruction : User
+    {
+        private protected Instruction(LLVMValueRef handle) : base(handle.IsAInstruction, LLVMValueKind.LLVMInstructionValueKind)
+        {
+        }
+
+        internal static new Instruction Create(LLVMValueRef handle) => handle switch
+        {
+            _ when handle.IsAUnaryOperator != null => new UnaryOperator(handle),
+            _ when handle.IsABinaryOperator != null => new BinaryOperator(handle),
+            _ when handle.IsACallInst != null => CallInst.Create(handle),
+            _ when handle.IsACmpInst != null => CmpInst.Create(handle),
+            _ when handle.IsAExtractElementInst != null => new ExtractElementInst(handle),
+            _ when handle.IsAGetElementPtrInst != null => new GetElementPtrInst(handle),
+            _ when handle.IsAInsertElementInst != null => new InsertElementInst(handle),
+            _ when handle.IsAInsertValueInst != null => new InsertValueInst(handle),
+            _ when handle.IsALandingPadInst != null => new LandingPadInst(handle),
+            _ when handle.IsAPHINode != null => new PHINode(handle),
+            _ when handle.IsASelectInst != null => new SelectInst(handle),
+            _ when handle.IsAShuffleVectorInst != null => new ShuffleVectorInst(handle),
+            _ when handle.IsAStoreInst != null => new StoreInst(handle),
+            _ when handle.IsABranchInst != null => new BranchInst(handle),
+            _ when handle.IsAIndirectBrInst != null => new IndirectBrInst(handle),
+            _ when handle.IsAInvokeInst != null => new InvokeInst(handle),
+            _ when handle.IsAReturnInst != null => new ReturnInst(handle),
+            _ when handle.IsASwitchInst != null => new SwitchInst(handle),
+            _ when handle.IsAUnreachableInst != null => new UnreachableInst(handle),
+            _ when handle.IsAResumeInst != null => new ResumeInst(handle),
+            _ when handle.IsACleanupReturnInst != null => new CleanupReturnInst(handle),
+            _ when handle.IsACatchReturnInst != null => new CatchReturnInst(handle),
+            _ when handle.IsACatchSwitchInst != null => new CatchSwitchInst(handle),
+            _ when handle.IsACallBrInst != null => new CallBrInst(handle),
+            _ when handle.IsAFuncletPadInst != null => FuncletPadInst.Create(handle),
+            _ when handle.IsAUnaryInstruction != null => UnaryInstruction.Create(handle),
+            _ when handle.IsAAtomicCmpXchgInst != null => new AtomicCmpXchgInst(handle),
+            _ when handle.IsAAtomicRMWInst != null => new AtomicRMWInst(handle),
+            _ when handle.IsAFenceInst != null => new FenceInst(handle),
+            _ => new Instruction(handle),
+        };
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/IntToPtrInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/IntToPtrInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class IntToPtrInst : CastInst
+    {
+        internal IntToPtrInst(LLVMValueRef handle) : base(handle.IsAIntToPtrInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/IntrinsicInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/IntrinsicInst.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class IntrinsicInst : CallInst
+    {
+        private protected IntrinsicInst(LLVMValueRef handle) : base(handle.IsAIntrinsicInst)
+        {
+        }
+
+        internal static new IntrinsicInst Create(LLVMValueRef handle) => handle switch
+        {
+            _ when handle.IsADbgInfoIntrinsic != null => DbgInfoIntrinsic.Create(handle),
+            _ when handle.IsAMemIntrinsic != null => MemIntrinsic.Create(handle),
+            _ => new IntrinsicInst(handle),
+        };
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/InvokeInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/InvokeInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class InvokeInst : CallBase
+    {
+        internal InvokeInst(LLVMValueRef handle) : base(handle.IsAInvokeInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/LandingPadInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/LandingPadInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class LandingPadInst : Instruction
+    {
+        internal LandingPadInst(LLVMValueRef handle) : base(handle.IsALandingPadInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/LoadInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/LoadInst.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class LoadInst : UnaryInstruction
+    {
+        internal LoadInst(LLVMValueRef handle) : base(handle.IsALoadInst)
+        {
+        }
+
+        public uint Alignment
+        {
+            get => Handle.Alignment;
+            set => Handle.SetAlignment(value);
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/MemCpyInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/MemCpyInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class MemCpyInst : MemTransferInst
+    {
+        internal MemCpyInst(LLVMValueRef handle) : base(handle.IsAMemCpyInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/MemIntrinsic.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/MemIntrinsic.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class MemIntrinsic : MemIntrinsicBase
+    {
+        private protected MemIntrinsic(LLVMValueRef handle) : base(handle.IsAMemIntrinsic)
+        {
+        }
+
+        internal static new MemIntrinsic Create(LLVMValueRef handle) => handle switch
+        {
+            _ when handle.IsAMemCpyInst != null => new MemCpyInst(handle),
+            _ when handle.IsAMemMoveInst != null => new MemMoveInst(handle),
+            _ when handle.IsAMemSetInst != null => new MemSetInst(handle),
+            _ => new MemIntrinsic(handle),
+        };
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/MemIntrinsicBase.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/MemIntrinsicBase.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class MemIntrinsicBase : IntrinsicInst
+    {
+        private protected MemIntrinsicBase(LLVMValueRef handle) : base(handle)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/MemMoveInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/MemMoveInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class MemMoveInst : MemTransferInst
+    {
+        internal MemMoveInst(LLVMValueRef handle) : base(handle.IsAMemMoveInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/MemSetBase.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/MemSetBase.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class MemSetBase : MemIntrinsic
+    {
+        private protected MemSetBase(LLVMValueRef handle) : base(handle)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/MemSetInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/MemSetInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class MemSetInst : MemSetBase
+    {
+        internal MemSetInst(LLVMValueRef handle) : base(handle.IsAMemSetInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/MemTransferBase.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/MemTransferBase.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class MemTransferBase : MemIntrinsic
+    {
+        private protected MemTransferBase(LLVMValueRef handle) : base(handle)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/MemTransferInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/MemTransferInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class MemTransferInst : MemTransferBase
+    {
+        private protected MemTransferInst(LLVMValueRef handle) : base(handle)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/PHINode.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/PHINode.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class PHINode : Instruction
+    {
+        internal PHINode(LLVMValueRef handle) : base(handle.IsAPHINode)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/PtrToIntInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/PtrToIntInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class PtrToIntInst : CastInst
+    {
+        internal PtrToIntInst(LLVMValueRef handle) : base(handle.IsAPtrToIntInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/ResumeInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/ResumeInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class ResumeInst : Instruction
+    {
+        internal ResumeInst(LLVMValueRef handle) : base(handle.IsAResumeInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/ReturnInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/ReturnInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class ReturnInst : Instruction
+    {
+        internal ReturnInst(LLVMValueRef handle) : base(handle.IsAReturnInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/SExtInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/SExtInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class SExtInst : CastInst
+    {
+        internal SExtInst(LLVMValueRef handle) : base(handle.IsASExtInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/SIToFPInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/SIToFPInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class SIToFPInst : CastInst
+    {
+        internal SIToFPInst(LLVMValueRef handle) : base(handle.IsASIToFPInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/SelectInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/SelectInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class SelectInst : Instruction
+    {
+        internal SelectInst(LLVMValueRef handle) : base(handle.IsASelectInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/ShuffleVectorInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/ShuffleVectorInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class ShuffleVectorInst : Instruction
+    {
+        internal ShuffleVectorInst(LLVMValueRef handle) : base(handle.IsAShuffleVectorInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/StoreInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/StoreInst.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class StoreInst : Instruction
+    {
+        internal StoreInst(LLVMValueRef handle) : base(handle.IsAStoreInst)
+        {
+        }
+
+        public uint Alignment
+        {
+            get => Handle.Alignment;
+            set => Handle.SetAlignment(value);
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/SwitchInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/SwitchInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class SwitchInst : Instruction
+    {
+        internal SwitchInst(LLVMValueRef handle) : base(handle.IsASwitchInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/TruncInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/TruncInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class TruncInst : CastInst
+    {
+        internal TruncInst(LLVMValueRef handle) : base(handle.IsATruncInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/UIToFPInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/UIToFPInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class UIToFPInst : CastInst
+    {
+        internal UIToFPInst(LLVMValueRef handle) : base(handle.IsAUIToFPInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/UnaryInstruction.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/UnaryInstruction.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class UnaryInstruction : Instruction
+    {
+        private protected UnaryInstruction(LLVMValueRef handle) : base(handle.IsAUnaryInstruction)
+        {
+        }
+
+        internal static new UnaryInstruction Create(LLVMValueRef handle) => handle switch
+        {
+            _ when handle.IsAAllocaInst != null => new AllocaInst(handle),
+            _ when handle.IsACastInst != null => CastInst.Create(handle),
+            _ when handle.IsAExtractValueInst != null => new ExtractValueInst(handle),
+            _ when handle.IsALoadInst != null => new LoadInst(handle),
+            _ when handle.IsAVAArgInst != null => new VAArgInst(handle),
+            _ when handle.IsAFreezeInst != null => new FreezeInst(handle),
+            _ => new UnaryInstruction(handle),
+        };
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/UnaryOperator.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/UnaryOperator.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class UnaryOperator : UnaryInstruction
+    {
+        internal UnaryOperator(LLVMValueRef handle) : base(handle.IsAUnaryOperator)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/UnreachableInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/UnreachableInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class UnreachableInst : Instruction
+    {
+        internal UnreachableInst(LLVMValueRef handle) : base(handle.IsAUnreachableInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/VAArgInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/VAArgInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class VAArgInst : UnaryInstruction
+    {
+        internal VAArgInst(LLVMValueRef handle) : base(handle.IsAVAArgInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/Instructions/ZExtInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/ZExtInst.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public sealed class ZExtInst : CastInst
+    {
+        internal ZExtInst(LLVMValueRef handle) : base(handle.IsAZExtInst)
+        {
+        }
+    }
+}

--- a/sources/LLVMSharp/Values/Users/User.cs
+++ b/sources/LLVMSharp/Values/Users/User.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class User : Value
+    {
+        private protected User(LLVMValueRef handle, LLVMValueKind expectedValueKind) : base(handle.IsAUser, expectedValueKind)
+        {
+        }
+
+        internal new static User Create(LLVMValueRef handle) => handle switch
+        {
+            _ when handle.IsAConstant != null => Constant.Create(handle),
+            _ when handle.IsAInstruction != null => Instruction.Create(handle),
+            _ when handle.Kind == LLVMValueKind.LLVMMemoryDefValueKind => new MemoryDef(handle),
+            _ when handle.Kind == LLVMValueKind.LLVMMemoryPhiValueKind => new MemoryPhi(handle),
+            _ when handle.Kind == LLVMValueKind.LLVMMemoryUseValueKind => new MemoryUse(handle),
+            _ => new User(handle, handle.Kind),
+        };
+    }
+}

--- a/sources/LLVMSharp/Values/Value.cs
+++ b/sources/LLVMSharp/Values/Value.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
+
+using System;
+using LLVMSharp.Interop;
+
+namespace LLVMSharp
+{
+    public class Value : IEquatable<Value>
+    {
+        private protected Value(LLVMValueRef handle, LLVMValueKind expectedValueKind)
+        {
+            if (handle.Kind != expectedValueKind)
+            {
+                throw new ArgumentException(nameof(handle));
+            }
+            Handle = handle;
+        }
+
+        public LLVMValueRef Handle { get; }
+
+        public static bool operator ==(Value left, Value right) => (left is object) ? ((right is object) && (left.Handle == right.Handle)) : (right is null);
+
+        public static bool operator !=(Value left, Value right) => (left is object) ? ((right is null) || (left.Handle != right.Handle)) : (right is object);
+
+        public override bool Equals(object obj) => (obj is Value other) && Equals(other);
+
+        public bool Equals(Value other) => this == other;
+
+        public override int GetHashCode() => Handle.GetHashCode();
+
+        public override string ToString() => Handle.ToString();
+
+        internal static Value Create(LLVMValueRef handle) => handle switch
+        {
+            _ when handle.IsAArgument != null => new Argument(handle),
+            _ when handle.IsABasicBlock != null => new BasicBlock(handle),
+            _ when handle.IsAInlineAsm != null => new InlineAsm(handle),
+            _ when handle.IsAUser != null => User.Create(handle),
+            _ when handle.Kind == LLVMValueKind.LLVMMetadataAsValueValueKind => new MetadataAsValue(handle),
+            _ => new Value(handle, handle.Kind),
+        };
+    }
+}


### PR DESCRIPTION
This adds a proper managed wrapper that loosely mirrors the LLVM object-oriented API surface available in C++.