### PR TITLE
Expose Set/GetSubprogram on DIBuilderRef

### DIFF
--- a/sources/LLVMSharp/Interop.Extensions/LLVMDIBuilderRef.cs
+++ b/sources/LLVMSharp/Interop.Extensions/LLVMDIBuilderRef.cs
@@ -101,6 +101,16 @@ namespace LLVMSharp.Interop
             return LLVM.DIBuilderCreateTypedef(this, Type, marshaledName, (UIntPtr)nameLength, File, LineNo, Scope, AlignInBits);
         }
 
+        public static LLVMMetadataRef GetSubprogram(LLVMValueRef Function)
+        {
+            return LLVM.GetSubprogram(Function);
+        }
+
+        public static void SetSubprogram(LLVMValueRef Function, LLVMMetadataRef Type)
+        {
+            LLVM.SetSubprogram(Function, Type);
+        }
+
         public void DIBuilderFinalize()
         {
             LLVM.DIBuilderFinalize(this);


### PR DESCRIPTION
The ability to set DWARF sub programs has been lost since v6 I think, these statics add the ability to get it back.