### PR TITLE
Clarify LLVM release in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ LLVMSharp is a multi-platform .NET Standard library for accessing the LLVM infra
 
 [![Join the chat at https://gitter.im/mjsabby/LLVMSharp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mjsabby/LLVMSharp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[**LLVMSharp 5.0 NuGet Package**](http://www.nuget.org/packages/LLVMSharp/5.0.0) for .NET Core 2.0+ (Linux, macOS, Windows) and .NET Framework 4+ - built from the LLVM 5.0.0 Release.
+[**LLVMSharp NuGet Package**](http://www.nuget.org/packages/LLVMSharp) for .NET Core 2.0+ (Linux, macOS, Windows) and .NET Framework 4+ - each version is built from the corresponding LLVM Release.
 
 ## Building LLVMSharp
 


### PR DESCRIPTION
I was reading the readme and thought "oh this is using an old LLVM release" but there are actually packages for newer versions on nuget.org.