### PR TITLE
Expose GetTargetFromTriple from LLVMTargetRef

### DIFF
--- a/sources/LLVMSharp/Interop.Extensions/LLVMTargetMachineRef.cs
+++ b/sources/LLVMSharp/Interop.Extensions/LLVMTargetMachineRef.cs
@@ -22,18 +22,7 @@ namespace LLVMSharp.Interop
 
         public static bool operator !=(LLVMTargetMachineRef left, LLVMTargetMachineRef right) => !(left == right);
 
-        public string CreateTargetDataLayout()
-        {
-            var pDataLayout = LLVM.CreateTargetDataLayout(this);
-
-            if (pDataLayout is null)
-            {
-                return string.Empty;
-            }
-
-            var span = new ReadOnlySpan<byte>(pDataLayout, int.MaxValue);
-            return span.Slice(0, span.IndexOf((byte)'\0')).AsString();
-        }
+        public LLVMTargetDataRef CreateTargetDataLayout() => LLVM.CreateTargetDataLayout(this);
 
         public void EmitToFile(LLVMModuleRef module, string fileName, LLVMCodeGenFileType codegen) => EmitToFile(module, fileName.AsSpan(), codegen);
 

--- a/tests/LLVMSharp.UnitTests/TargetData.cs
+++ b/tests/LLVMSharp.UnitTests/TargetData.cs
@@ -67,5 +67,29 @@ namespace LLVMSharp.UnitTests
             LLVMValueRef global = m.AddGlobal(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), "someGlobal");
             Assert.AreEqual(4, target.PreferredAlignmentOfGlobal(global));
         }
+
+        private LLVMTargetDataRef TargetDataFromTriple(string triple)
+        {
+            LLVMTargetRef target = LLVMTargetRef.GetTargetFromTriple(triple);
+            LLVMTargetMachineRef targetMachine = target.CreateTargetMachine(triple, "", "",
+                LLVMCodeGenOptLevel.LLVMCodeGenLevelDefault, LLVMRelocMode.LLVMRelocDefault,
+                LLVMCodeModel.LLVMCodeModelDefault);
+            return targetMachine.CreateTargetDataLayout();
+        }
+
+        [Test]
+        public void MachineTest()
+        {
+            LLVM.InitializeX86TargetInfo();
+            LLVM.InitializeX86Target();
+            LLVM.InitializeX86TargetMC();
+
+            LLVMTypeRef pointerType = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int32, 0);
+            LLVMTargetDataRef x86 = TargetDataFromTriple("i386-unknown-unknown");
+            LLVMTargetDataRef x86_64 = TargetDataFromTriple("amd64-unknown-unknown");
+
+            Assert.AreEqual(4, x86.ABISizeOfType(pointerType));
+            Assert.AreEqual(8, x86_64.ABISizeOfType(pointerType));
+        }
     }
 }


### PR DESCRIPTION
This adds GetTargetFromTriple as a static method of LLVMTargetRef. Also fixes the erroneous return type of LLVMTargetMachineRef.CreateTargetDataLayout.

Includes unit test with coverage of both.