### PR TITLE
Fix #178

### DIFF
--- a/sources/LLVMSharp.Interop/Extensions/LLVMModuleRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMModuleRef.cs
@@ -126,14 +126,6 @@ namespace LLVMSharp.Interop
             return LLVM.AddGlobalInAddressSpace(this, Ty, marshaledName, AddressSpace);
         }
 
-        public void AddNamedMetadataOperand(string Name, LLVMValueRef Val) => AddNamedMetadataOperand(Name.AsSpan(), Val);
-
-        public void AddNamedMetadataOperand(ReadOnlySpan<char> Name, LLVMValueRef Val)
-        {
-            using var marshaledName = new MarshaledString(Name);
-            LLVM.AddNamedMetadataOperand(this, marshaledName, Val);
-        }
-
         public void AddModuleFlag(string FlagName, LLVMModuleFlagBehavior Behavior, uint Val) => AddModuleFlag(FlagName.AsSpan(), Behavior, Val);
 
         public void AddModuleFlag(ReadOnlySpan<char> FlagName, LLVMModuleFlagBehavior Behavior, uint Val)
@@ -141,6 +133,14 @@ namespace LLVMSharp.Interop
             using var marshaledName = new MarshaledString(FlagName);
             LLVMOpaqueMetadata* valAsMetadata = LLVM.ValueAsMetadata(LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, Val));
             LLVM.AddModuleFlag(this, Behavior, marshaledName, (UIntPtr)FlagName.Length, valAsMetadata);
+        }
+
+        public void AddNamedMetadataOperand(string Name, LLVMValueRef Val) => AddNamedMetadataOperand(Name.AsSpan(), Val);
+
+        public void AddNamedMetadataOperand(ReadOnlySpan<char> Name, LLVMValueRef Val)
+        {
+            using var marshaledName = new MarshaledString(Name);
+            LLVM.AddNamedMetadataOperand(this, marshaledName, Val);
         }
 
         public LLVMDIBuilderRef CreateDIBuilder()
@@ -264,6 +264,11 @@ namespace LLVMSharp.Interop
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.GetTypeByName(this, marshaledName);
+        }
+
+        public int LinkInModule(LLVMModuleRef OtherModule)
+        {
+            return LLVM.LinkModules2(this, OtherModule);
         }
 
         public void PrintToFile(string Filename) => PrintToFile(Filename.AsSpan());

--- a/sources/LLVMSharp.Interop/Extensions/LLVMModuleRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMModuleRef.cs
@@ -134,6 +134,15 @@ namespace LLVMSharp.Interop
             LLVM.AddNamedMetadataOperand(this, marshaledName, Val);
         }
 
+        public void AddModuleFlag(string FlagName, LLVMModuleFlagBehavior Behavior, uint Val) => AddModuleFlag(FlagName.AsSpan(), Behavior, Val);
+
+        public void AddModuleFlag(ReadOnlySpan<char> FlagName, LLVMModuleFlagBehavior Behavior, uint Val)
+        {
+            using var marshaledName = new MarshaledString(FlagName);
+            LLVMOpaqueMetadata* valAsMetadata = LLVM.ValueAsMetadata(LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, Val));
+            LLVM.AddModuleFlag(this, Behavior, marshaledName, (UIntPtr)FlagName.Length, valAsMetadata);
+        }
+
         public LLVMDIBuilderRef CreateDIBuilder()
         {
             return new LLVMDIBuilderRef((IntPtr)LLVM.CreateDIBuilder(this));

--- a/sources/LLVMSharp.Interop/LLVMModuleFlagBehavior.cs
+++ b/sources/LLVMSharp.Interop/LLVMModuleFlagBehavior.cs
@@ -7,7 +7,7 @@ namespace LLVMSharp.Interop
 {
     public enum LLVMModuleFlagBehavior
     {
-        LLVMModuleFlagBehaviorError,
+        LLVMModuleFlagBehaviorError = 1,
         LLVMModuleFlagBehaviorWarning,
         LLVMModuleFlagBehaviorRequire,
         LLVMModuleFlagBehaviorOverride,

--- a/sources/LLVMSharp.Interop/LLVMModuleFlagBehavior.cs
+++ b/sources/LLVMSharp.Interop/LLVMModuleFlagBehavior.cs
@@ -7,7 +7,7 @@ namespace LLVMSharp.Interop
 {
     public enum LLVMModuleFlagBehavior
     {
-        LLVMModuleFlagBehaviorError = 1,
+        LLVMModuleFlagBehaviorError,
         LLVMModuleFlagBehaviorWarning,
         LLVMModuleFlagBehaviorRequire,
         LLVMModuleFlagBehaviorOverride,

--- a/tests/LLVMSharp.UnitTests/Interop/LLVMOpaqueModuleTests.cs
+++ b/tests/LLVMSharp.UnitTests/Interop/LLVMOpaqueModuleTests.cs
@@ -26,43 +26,33 @@ namespace LLVMSharp.Interop.UnitTests
             Assert.That(typeof(LLVMOpaqueModule).IsLayoutSequential, Is.True);
         }
 
-        /// <summary>Validates that the <see cref="LLVMOpaqueModule" /> struct has the correct size.</summary>
+        /// <summary><see cref="LLVMOpaqueModule" /> struct should have the correct size of 1.</summary>
         [Test]
         public static void SizeOfTest()
         {
-            Assert.That(sizeof(LLVMOpaqueModule), Is.EqualTo(1));
+            Assert.That(sizeof(LLVMOpaqueModule), Is.EqualTo(1), "LLVMOpaqueModule struct should have the correct size 1");
         }
 
-        [Test(Description = "Tests LLVMModuleFlagBehavior")]
-        /// <summary>Validates that <see cref="LLVMModuleFlagBehavior.LLVMModuleFlagBehaviorWarning"/> does not cause an error.</summary>
-        public static void TestLLVMModuleFlagBehavior()
+        [Test(Description = "Tests that LLVMModuleFlagBehavior is properly defined as a 0-based enum for use in AddModuleFlag")]
+        /// <summary>Verifies that <see cref="LLVMModuleFlagBehavior"/> is defined as expected by <see cref="AddModuleFlag"/>
+        /// so that there isn't unexpected behavior when modules with conflicting flags are linked.
+        /// This test is relevant because AddModuleFlag expects a 0-based behavior enum (where 1 defines warning),
+        /// while the other method of adding a module flag (AddNamedMetadataOperand) expects a 1-based behavior
+        /// (where 1 defines error).</summary>
+        public static void TestBehaviorOfLinkingConflictingModules()
         {
             // set up two modules
             LLVMModuleRef module1 = LLVMModuleRef.CreateWithName("module1");
             LLVMModuleRef module2 = LLVMModuleRef.CreateWithName("module2");
 
-            // Add conflicting module flags to module and module2 using LLVMModuleFlagBehavior.LLVMModuleFlagBehaviorWarning
+            // Add conflicting module flags to module1 and module2 using LLVMModuleFlagBehavior.LLVMModuleFlagBehaviorWarning
             // which should only cause a warning, and not an error
-            string flagName = "flagname";
-            LLVMValueRef value1 = LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, 1);
-            LLVMValueRef value2 = LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, 2);
-            ulong enumBasedBehavior = (ulong)LLVMModuleFlagBehavior.LLVMModuleFlagBehaviorWarning;
+            string flagName = "madeUpFlagName";
+            uint value1 = 1;
+            uint value2 = 2;
 
-            var flagNode1 = LLVMValueRef.CreateMDNode(new[]
-            {
-                LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, enumBasedBehavior),
-                module1.Context.GetMDString(flagName, (uint)flagName.Length),
-                value1,
-            });
-            module1.AddNamedMetadataOperand("llvm.module.flags", flagNode1);
-
-            var flagNode2 = LLVMValueRef.CreateMDNode(new[]
-            {
-                LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, enumBasedBehavior),
-                module1.Context.GetMDString(flagName, (uint)flagName.Length),
-                value2
-            });
-            module2.AddNamedMetadataOperand("llvm.module.flags", flagNode2);
+            module1.AddModuleFlag(flagName, LLVMModuleFlagBehavior.LLVMModuleFlagBehaviorWarning, value1);
+            module2.AddModuleFlag(flagName, LLVMModuleFlagBehavior.LLVMModuleFlagBehaviorWarning, value2);
 
             // linking the modules should cause a warning, not an error
             try
@@ -71,17 +61,9 @@ namespace LLVMSharp.Interop.UnitTests
             }
             catch (AccessViolationException)
             {
-                Assert.Fail(); //  Doesn't actually get called. See note below.
+                // Fail doesn't actually get called. The test will simply be aborted if we reach this point, but the catch block cleans up the error output
+                Assert.Fail("Conflicting module flags that were defined with LLVMModuleFlagBehaviorWarning should not have caused an error.");
             }
-
-            // Would be nice to actually see if an error is thrown and Fail instead of crashing on an error.
-            // Also would be nice to actually see if a warning is thrown. However, using a try/catch block isn't enough.
-            // The warning doesn't even get caught as an Exception. And the error can be caught but not handled.
-            // I'm not sure the proper way to do that.
-            // Having this try catch block at least causes the output to just say
-            // "The active test run was aborted. Reason: Test host process crashed :
-            // error: linking module flags 'flagname': IDs have conflicting values in 'module2' and 'module1'"
-            // in the case of an error instead of crashing with a giant stack trace.
         }
     }
 }

--- a/tests/LLVMSharp.UnitTests/Interop/LLVMOpaqueModuleTests.cs
+++ b/tests/LLVMSharp.UnitTests/Interop/LLVMOpaqueModuleTests.cs
@@ -30,7 +30,6 @@ namespace LLVMSharp.Interop.UnitTests
         [Test]
         public static void SizeOfTest()
         {
-            TestContext.WriteLine("Testing");
             Assert.That(sizeof(LLVMOpaqueModule), Is.EqualTo(1));
         }
 

--- a/tests/LLVMSharp.UnitTests/Interop/LLVMOpaqueModuleTests.cs
+++ b/tests/LLVMSharp.UnitTests/Interop/LLVMOpaqueModuleTests.cs
@@ -5,6 +5,7 @@
 
 using NUnit.Framework;
 using System.Runtime.InteropServices;
+using System;
 
 namespace LLVMSharp.Interop.UnitTests
 {
@@ -29,7 +30,59 @@ namespace LLVMSharp.Interop.UnitTests
         [Test]
         public static void SizeOfTest()
         {
+            TestContext.WriteLine("Testing");
             Assert.That(sizeof(LLVMOpaqueModule), Is.EqualTo(1));
+        }
+
+        [Test(Description = "Tests LLVMModuleFlagBehavior")]
+        /// <summary>Validates that <see cref="LLVMModuleFlagBehavior.LLVMModuleFlagBehaviorWarning"/> does not cause an error.</summary>
+        public static void TestLLVMModuleFlagBehavior()
+        {
+            // set up two modules
+            LLVMModuleRef module1 = LLVMModuleRef.CreateWithName("module1");
+            LLVMModuleRef module2 = LLVMModuleRef.CreateWithName("module2");
+
+            // Add conflicting module flags to module and module2 using LLVMModuleFlagBehavior.LLVMModuleFlagBehaviorWarning
+            // which should only cause a warning, and not an error
+            string flagName = "flagname";
+            LLVMValueRef value1 = LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, 1);
+            LLVMValueRef value2 = LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, 2);
+            ulong enumBasedBehavior = (ulong)LLVMModuleFlagBehavior.LLVMModuleFlagBehaviorWarning;
+
+            var flagNode1 = LLVMValueRef.CreateMDNode(new[]
+            {
+                LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, enumBasedBehavior),
+                module1.Context.GetMDString(flagName, (uint)flagName.Length),
+                value1,
+            });
+            module1.AddNamedMetadataOperand("llvm.module.flags", flagNode1);
+
+            var flagNode2 = LLVMValueRef.CreateMDNode(new[]
+            {
+                LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, enumBasedBehavior),
+                module1.Context.GetMDString(flagName, (uint)flagName.Length),
+                value2
+            });
+            module2.AddNamedMetadataOperand("llvm.module.flags", flagNode2);
+
+            // linking the modules should cause a warning, not an error
+            try
+            {
+                LLVM.LinkModules2(module1, module2);
+            }
+            catch (AccessViolationException)
+            {
+                Assert.Fail(); //  Doesn't actually get called. See note below.
+            }
+
+            // Would be nice to actually see if an error is thrown and Fail instead of crashing on an error.
+            // Also would be nice to actually see if a warning is thrown. However, using a try/catch block isn't enough.
+            // The warning doesn't even get caught as an Exception. And the error can be caught but not handled.
+            // I'm not sure the proper way to do that.
+            // Having this try catch block at least causes the output to just say
+            // "The active test run was aborted. Reason: Test host process crashed :
+            // error: linking module flags 'flagname': IDs have conflicting values in 'module2' and 'module1'"
+            // in the case of an error instead of crashing with a giant stack trace.
         }
     }
 }

--- a/tests/LLVMSharp.UnitTests/Interop/LLVMOpaqueModuleTests.cs
+++ b/tests/LLVMSharp.UnitTests/Interop/LLVMOpaqueModuleTests.cs
@@ -5,7 +5,6 @@
 
 using NUnit.Framework;
 using System.Runtime.InteropServices;
-using System;
 
 namespace LLVMSharp.Interop.UnitTests
 {
@@ -31,39 +30,6 @@ namespace LLVMSharp.Interop.UnitTests
         public static void SizeOfTest()
         {
             Assert.That(sizeof(LLVMOpaqueModule), Is.EqualTo(1), "LLVMOpaqueModule struct should have the correct size 1");
-        }
-
-        [Test(Description = "Tests that LLVMModuleFlagBehavior is properly defined as a 0-based enum for use in AddModuleFlag")]
-        /// <summary>Verifies that <see cref="LLVMModuleFlagBehavior"/> is defined as expected by <see cref="AddModuleFlag"/>
-        /// so that there isn't unexpected behavior when modules with conflicting flags are linked.
-        /// This test is relevant because AddModuleFlag expects a 0-based behavior enum (where 1 defines warning),
-        /// while the other method of adding a module flag (AddNamedMetadataOperand) expects a 1-based behavior
-        /// (where 1 defines error).</summary>
-        public static void TestBehaviorOfLinkingConflictingModules()
-        {
-            // set up two modules
-            LLVMModuleRef module1 = LLVMModuleRef.CreateWithName("module1");
-            LLVMModuleRef module2 = LLVMModuleRef.CreateWithName("module2");
-
-            // Add conflicting module flags to module1 and module2 using LLVMModuleFlagBehavior.LLVMModuleFlagBehaviorWarning
-            // which should only cause a warning, and not an error
-            string flagName = "madeUpFlagName";
-            uint value1 = 1;
-            uint value2 = 2;
-
-            module1.AddModuleFlag(flagName, LLVMModuleFlagBehavior.LLVMModuleFlagBehaviorWarning, value1);
-            module2.AddModuleFlag(flagName, LLVMModuleFlagBehavior.LLVMModuleFlagBehaviorWarning, value2);
-
-            // linking the modules should cause a warning, not an error
-            try
-            {
-                LLVM.LinkModules2(module1, module2);
-            }
-            catch (AccessViolationException)
-            {
-                // Fail doesn't actually get called. The test will simply be aborted if we reach this point, but the catch block cleans up the error output
-                Assert.Fail("Conflicting module flags that were defined with LLVMModuleFlagBehaviorWarning should not have caused an error.");
-            }
         }
     }
 }


### PR DESCRIPTION
Fixes the bug where the LLVMModuleFlagBehavior enum values are all off by 1 (https://github.com/microsoft/LLVMSharp/issues/178#issue-1051246758). Also creates a unit test to make sure that the enums aren't off by 1 by checking that LLVM.ModuleFlagBehaviorWarning doesn't cause an Error (which does happen in the existing version of LLVMSharp). There is a comment at the bottom of the unit test describing a way to improve the test if someone else knows how to implement this.