### PR TITLE
Fix #225: Implement libLLVMSharp custom functions

### DIFF
--- a/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
@@ -1161,4 +1161,8 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
     public readonly void ViewFunctionCFG() => LLVM.ViewFunctionCFG(this);
 
     public readonly void ViewFunctionCFGOnly() => LLVM.ViewFunctionCFGOnly(this);
+
+    public readonly LLVMTypeRef GetFunctionType() => LLVM.TypeOf(this);
+
+    public readonly LLVMTypeRef GetReturnType() => LLVM.GetReturnType(LLVM.TypeOf(this));
 }

--- a/tests/LLVMSharp.UnitTests/Functions.cs
+++ b/tests/LLVMSharp.UnitTests/Functions.cs
@@ -28,4 +28,36 @@ public class Functions
         var attrs = functionValue.GetAttributesAtIndex((LLVMAttributeIndex)1);
         Assert.That((AttributeKind)attrs[0].KindAsEnum, Is.EqualTo(AttributeKind.ByVal));
     }
+
+    [Test]
+    public void LibLLVMSharp_GetFunctionType()
+    {
+        var module = LLVMModuleRef.CreateWithName("Test Module");
+        var returnType = LLVMTypeRef.Int32;
+        var paramTypes = new[] { LLVMTypeRef.Int32, LLVMTypeRef.Int32 };
+        var functionType = LLVMTypeRef.CreateFunction(returnType, paramTypes);
+        var functionValue = module.AddFunction("add", functionType);
+        
+        var retrievedFunctionType = functionValue.GetFunctionType();
+        
+        Assert.That(retrievedFunctionType.Kind, Is.EqualTo(LLVMTypeKind.LLVMFunctionTypeKind));
+        
+        Assert.That(retrievedFunctionType.GetReturnType().Kind, Is.EqualTo(LLVMTypeKind.LLVMIntegerTypeKind));
+        
+        Assert.That(retrievedFunctionType.ParamTypesCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void LibLLVMSharp_GetReturnType()
+    {
+        var module = LLVMModuleRef.CreateWithName("Test Module");
+        var returnType = LLVMTypeRef.Int32;
+        var functionType = LLVMTypeRef.CreateFunction(returnType, [LLVMTypeRef.Int32, LLVMTypeRef.Int32]);
+        var functionValue = module.AddFunction("add", functionType);
+        
+        var retrievedReturnType = functionValue.GetReturnType();
+        
+        Assert.That(retrievedReturnType.Kind, Is.EqualTo(LLVMTypeKind.LLVMIntegerTypeKind));
+        Assert.That(retrievedReturnType.Handle, Is.EqualTo(returnType.Handle));
+    }
 }


### PR DESCRIPTION
## Fixes #225 - Implement libLLVMSharp custom functions

### Changes:
- Added `GetFunctionType()` extension method to `LLVMValueRef`
- Added `GetReturnType()` extension method to `LLVMValueRef`  
- Added comprehensive unit tests for both functions

### Implementation:
- Uses existing LLVM APIs (`LLVM.TypeOf` and `LLVM.GetReturnType`)
- Follows established codebase patterns

### Testing:
- Added 2 unit tests that verify functionality
- Tests check function type retrieval and return type extraction
- All tests follow existing test patterns

### Usage:
```csharp
var functionType = myFunction.GetFunctionType();
var returnType = myFunction.GetReturnType();
```
