### PR TITLE
Use single-target TargetFramework element to match ClangSharp

### DIFF
--- a/sources/LLVMSharp.Interop/LLVMSharp.Interop.csproj
+++ b/sources/LLVMSharp.Interop/LLVMSharp.Interop.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sources/LLVMSharp/LLVMSharp.csproj
+++ b/sources/LLVMSharp/LLVMSharp.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/LLVMSharp.UnitTests/LLVMSharp.UnitTests.csproj
+++ b/tests/LLVMSharp.UnitTests/LLVMSharp.UnitTests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Follow-up to #251 picking up the remaining infrastructure changes from latest ClangSharp.

ClangSharp dropped `net8.0` from its multi-targeting projects, leaving them on the singular `<TargetFramework>net10.0</TargetFramework>` element. These projects already build only `net10.0` but still expressed it via the plural `<TargetFrameworks>` element, so this aligns `LLVMSharp`, `LLVMSharp.Interop`, and `LLVMSharp.UnitTests` with that convention.

The other recent ClangSharp infra commits don''t apply here:
- The native-package regen workflow and the per-RID `pkg` upload steps are for ClangSharp''s `libClang`/`libClangSharp` runtime packages -- LLVMSharp ships no runtime packages (`libLLVM` comes from upstream).
- Nightly publishing was already removed in #251, and `global.json`, props/targets, and test dependencies are already in sync.

Build is clean (0 warnings) and all 2587 tests pass.

> [!NOTE]
> This PR body was drafted by Copilot.
