### PR TITLE
Add native-package regeneration workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,7 +13,7 @@ so you edit the right layer and validate correctly.
 | `sources/LLVMSharp.Interop/llvm/` | **Auto-generated** raw LLVM-C interop (from `sources/GenerateLLVM.rsp`; headers `Ported from llvm-project`). | **No** — regenerate, don't hand-edit. |
 | `sources/LLVMSharp.Interop/llvmsharp/` | **Auto-generated** raw interop for the `libLLVMSharp` native helper (from `sources/GenerateLLVMSharp.rsp`). | **No** — regenerate. |
 | `sources/LLVMSharp.Interop/{Manual,Extensions,Internals}/` | Hand-written interop helpers (typed handles like `LLVMValueRef`, extension methods, marshalling). | Yes. |
-| `sources/libLLVMSharp/` | Native C++ helper (CMake) exposing APIs missing from the LLVM-C API. Nascent; not yet packaged. Requires building LLVM. | Yes, for native surface. |
+| `sources/libLLVMSharp/` | Native C++ helper (CMake) exposing APIs missing from the LLVM-C API. Packaged as `libLLVMSharp.runtime.*` via `regenerate-native.yml`. Requires an LLVM release to build against. | Yes, for native surface. |
 | `tests/LLVMSharp.UnitTests/` | NUnit tests. `Interop/` + `InteropTests/` are generated interop tests; the rest are hand-written. | Yes. |
 
 If a change belongs in `sources/LLVMSharp.Interop/llvm/` (or `.../llvmsharp/`), it almost always belongs
@@ -78,10 +78,17 @@ these in the rsp; don't drop them expecting an external profile to supply them.
 ## Sibling repo — keep infra in sync with ClangSharp
 
 LLVMSharp shares its build/packaging infrastructure with **ClangSharp** and should stay in sync with it
-(props/targets, `scripts/`, `.github/workflows/ci.yml`, `global.json`), adjusting only for genuine per-repo
-differences. Notably, LLVMSharp publishes only agnostic managed packages (`LLVMSharp`,
-`LLVMSharp.Interop`) — it has no per-RID runtime packages — so it does **not** carry ClangSharp's
-per-platform package upload globs, and it has no `win32metadata` regression test.
+(props/targets, `scripts/`, `.github/workflows/*.yml`, `global.json`), adjusting only for genuine per-repo
+differences. Notably, LLVMSharp's `ci.yml` publishes only agnostic managed packages (`LLVMSharp`,
+`LLVMSharp.Interop`) — it has no per-RID runtime packages in that pipeline, so it does **not** carry
+ClangSharp's per-platform package upload globs there, and it has no `win32metadata` regression test.
+
+The native runtime packages (`libLLVM.runtime.*`, `libLLVMSharp.runtime.*`) are produced by the separate
+`.github/workflows/regenerate-native.yml` (mirroring ClangSharp's), with a key divergence: the official
+LLVM releases only ship a shared `libLLVM` on Windows (`LLVM-C.dll`), so Linux/macOS are lifted from
+apt.llvm.org (`libllvm<major>`) and Homebrew (`llvm`) respectively — which makes libLLVM a native-runner
+matrix rather than ClangSharp's single-Windows-runner libclang lift. `libLLVMSharp` compiles against the
+LLVM release the same way ClangSharp's `libClangSharp` does. See README's "Regenerating native binaries".
 
 Target the **same LLVM release that ClangSharp targets for Clang**. Version/packaging lives in
 `Directory.Build.props` (`VersionPrefix`) and `Directory.Packages.props` (`libLLVM` pin); bump them together,

--- a/.github/workflows/regenerate-native.yml
+++ b/.github/workflows/regenerate-native.yml
@@ -1,0 +1,303 @@
+name: regenerate-native
+
+# Regenerates the native runtime packages:
+#   * libLLVM.runtime.*         (the prebuilt shared libLLVM lifted per platform)
+#   * libLLVMSharp.runtime.*    (our helper library, compiled against the matching LLVM release)
+#
+# libLLVM regenerates when the tracked LLVM version changes (the version in the
+# top-level CMakeLists.txt, which maps to the llvmorg-<version> release tag). libLLVMSharp
+# regenerates for that same reason or whenever sources/libLLVMSharp changes. Both can also be
+# forced via workflow_dispatch. See the "Regenerating native binaries" section in README.md.
+#
+# Unlike ClangSharp (which lifts the shared libclang shipped for every platform), the official
+# LLVM releases only ship a shared libLLVM on Windows (as LLVM-C.dll). Linux and macOS are
+# therefore lifted from the most-official prebuilt source per platform: apt.llvm.org (the LLVM
+# project's own Debian/Ubuntu repository) on Linux and Homebrew on macOS. This is why libLLVM
+# runs as a per-runtime matrix on native runners rather than on a single Windows runner.
+#
+# The jobs upload the resulting .nupkg files as build artifacts and sign them via the
+# separate sign-nuget leg; publishing to NuGet is manual.
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      libllvm:
+        description: "Force regenerating the libLLVM runtime packages"
+        type: boolean
+        default: false
+      libllvmsharp:
+        description: "Force regenerating the libLLVMSharp runtime packages"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: regenerate-native-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      llvm-version: ${{ steps.detect.outputs.llvm-version }}
+      libllvm: ${{ steps.detect.outputs.libllvm }}
+      libllvmsharp: ${{ steps.detect.outputs.libllvmsharp }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - id: detect
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        parse_version() { sed -n 's/^project(LLVMSharp VERSION \([0-9.]*\)).*/\1/p' "$1"; }
+
+        # The top-level CMakeLists.txt is the source of truth for the tracked LLVM version.
+        version="$(parse_version CMakeLists.txt)"
+        if [ -z "${version}" ]; then echo "could not parse LLVM version from CMakeLists.txt" >&2; exit 1; fi
+        echo "llvm-version=${version}" >> "$GITHUB_OUTPUT"
+
+        libllvm=false
+        libllvmsharp=false
+
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ inputs.libllvm }}" = "true" ]; then libllvm=true; fi
+          if [ "${{ inputs.libllvmsharp }}" = "true" ]; then libllvmsharp=true; fi
+        else
+          before="${{ github.event.before }}"
+          if [ -z "${before}" ] || [ "${before}" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "${before}^{commit}" 2>/dev/null; then
+            # No usable baseline to diff against (new/recreated branch, force-push,
+            # unfetched history); regenerate everything conservatively.
+            libllvm=true
+            libllvmsharp=true
+          else
+            # libLLVM regenerates when the tracked LLVM version changes. The libLLVM package
+            # version tracks the full patch (e.g. 21.1.8), so compare the full version.
+            prev_version="$(git show "${before}:CMakeLists.txt" 2>/dev/null | sed -n 's/^project(LLVMSharp VERSION \([0-9.]*\)).*/\1/p')"
+            if [ "${version}" != "${prev_version}" ]; then
+              libllvm=true
+            fi
+
+            # libLLVMSharp regenerates for the same reason or when its sources change.
+            if [ "${libllvm}" = "true" ] || ! git diff --quiet "${before}" HEAD -- sources/libLLVMSharp/; then
+              libllvmsharp=true
+            fi
+          fi
+        fi
+
+        echo "libllvm=${libllvm}" >> "$GITHUB_OUTPUT"
+        echo "libllvmsharp=${libllvmsharp}" >> "$GITHUB_OUTPUT"
+        echo "Resolved: llvm=${version} (major.minor=${major_minor}) libllvm=${libllvm} libllvmsharp=${libllvmsharp}"
+    - name: Verify package versions match the tracked LLVM version
+      # Guards against bumping CMakeLists.txt without updating the nuspec/runtime.json
+      # versions. libLLVM versions must equal the LLVM version exactly; libLLVMSharp
+      # versions must be that version plus an independent build revision (e.g. 21.1.8.1).
+      shell: bash
+      run: |
+        set -euo pipefail
+        version="${{ steps.detect.outputs.llvm-version }}"
+        rc=0
+
+        nuspec_version() { sed -n 's:.*<version>\([^<]*\)</version>.*:\1:p' "$1" | head -n1; }
+        nuspec_branch()  { sed -n 's:.*<repository[^>]*branch="\([^"]*\)".*:\1:p' "$1" | head -n1; }
+        json_versions()  { grep -oE '"[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?"' "$1" | tr -d '"'; }
+
+        fail() { echo "::error file=$1::$2"; rc=1; }
+
+        if [ "${{ steps.detect.outputs.libllvm }}" = "true" ]; then
+          for f in packages/libLLVM/libLLVM/libLLVM.nuspec packages/libLLVM/libLLVM.runtime.*/*.nuspec; do
+            v="$(nuspec_version "$f")"
+            [ "${v}" = "${version}" ] || fail "$f" "version '${v}' does not match LLVM version '${version}'"
+            b="$(nuspec_branch "$f")"
+            if [ -n "${b}" ] && [ "${b}" != "llvmorg-${version}" ]; then
+              fail "$f" "repository branch '${b}' does not match 'llvmorg-${version}'"
+            fi
+          done
+          for v in $(json_versions packages/libLLVM/libLLVM/runtime.json); do
+            [ "${v}" = "${version}" ] || fail "packages/libLLVM/libLLVM/runtime.json" "mapped version '${v}' does not match LLVM version '${version}'"
+          done
+        fi
+
+        if [ "${{ steps.detect.outputs.libllvmsharp }}" = "true" ]; then
+          for f in packages/libLLVMSharp/libLLVMSharp/libLLVMSharp.nuspec packages/libLLVMSharp/libLLVMSharp.runtime.*/*.nuspec; do
+            v="$(nuspec_version "$f")"
+            case "${v}" in
+              "${version}".*) : ;;
+              *) fail "$f" "version '${v}' is not 'llvm-version.<revision>' (expected '${version}.<n>')" ;;
+            esac
+          done
+          for v in $(json_versions packages/libLLVMSharp/libLLVMSharp/runtime.json); do
+            case "${v}" in
+              "${version}".*) : ;;
+              *) fail "packages/libLLVMSharp/libLLVMSharp/runtime.json" "mapped version '${v}' is not '${version}.<revision>'" ;;
+            esac
+          done
+        fi
+
+        if [ "${rc}" -ne 0 ]; then
+          echo "Update the package versions to match the tracked LLVM version (${version}) before regenerating." >&2
+          exit 1
+        fi
+        echo "Package versions verified against LLVM ${version}"
+
+  # -------- libLLVM: lift the shared libLLVM from the most-official prebuilt source --------
+
+  libllvm-build:
+    needs: detect
+    if: ${{ needs.detect.outputs.libllvm == 'true' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - { rid: win-x64,     os: windows-latest }
+        - { rid: win-arm64,   os: windows-11-arm }
+        - { rid: linux-x64,   os: ubuntu-latest }
+        - { rid: linux-arm64, os: ubuntu-24.04-arm }
+        - { rid: osx-arm64,   os: macos-latest }
+    steps:
+    - uses: actions/checkout@v4
+    - name: Lift libLLVM (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: ./scripts/build.ps1 -regeneratenative -target libLLVM -rid ${{ matrix.rid }}
+    - name: Lift libLLVM (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: ./scripts/build.sh --regeneratenative --target libLLVM --rid ${{ matrix.rid }}
+    - uses: actions/upload-artifact@v4
+      with:
+        name: libllvm-native-${{ matrix.rid }}
+        path: artifacts/native/${{ matrix.rid }}/*
+        if-no-files-found: error
+
+  libllvm-pack:
+    needs: [ detect, libllvm-build ]
+    if: ${{ needs.detect.outputs.libllvm == 'true' }}
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: NuGet/setup-nuget@v2
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: libllvm-native-*
+        path: staging
+    - name: Pack libLLVM packages
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p out
+        for rid in win-x64 win-arm64 linux-x64 linux-arm64 osx-arm64; do
+          cp staging/"libllvm-native-${rid}"/* "packages/libLLVM/libLLVM.runtime.${rid}/"
+          nuget pack "packages/libLLVM/libLLVM.runtime.${rid}/libLLVM.runtime.${rid}.nuspec" -OutputDirectory out
+        done
+        nuget pack "packages/libLLVM/libLLVM/libLLVM.nuspec" -OutputDirectory out
+    - uses: actions/upload-artifact@v4
+      with:
+        name: libLLVM-packages
+        path: out/*.nupkg
+        if-no-files-found: error
+
+  # -------- libLLVMSharp: compile our helper against that same LLVM release --------
+
+  libllvmsharp-build:
+    needs: detect
+    if: ${{ needs.detect.outputs.libllvmsharp == 'true' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - { rid: win-x64,     os: windows-latest }
+        - { rid: win-arm64,   os: windows-11-arm }
+        - { rid: linux-x64,   os: ubuntu-latest }
+        - { rid: linux-arm64, os: ubuntu-24.04-arm }
+        - { rid: osx-arm64,   os: macos-latest }
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build libLLVMSharp (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: ./scripts/build.ps1 -regeneratenative -target libLLVMSharp -rid ${{ matrix.rid }}
+    - name: Build libLLVMSharp (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: ./scripts/build.sh --regeneratenative --target libLLVMSharp --rid ${{ matrix.rid }}
+    - uses: actions/upload-artifact@v4
+      with:
+        name: libllvmsharp-native-${{ matrix.rid }}
+        path: artifacts/native/${{ matrix.rid }}/*
+        if-no-files-found: error
+
+  libllvmsharp-pack:
+    needs: [ detect, libllvmsharp-build ]
+    if: ${{ needs.detect.outputs.libllvmsharp == 'true' }}
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: NuGet/setup-nuget@v2
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: libllvmsharp-native-*
+        path: staging
+    - name: Pack libLLVMSharp packages
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p out
+        for rid in win-x64 win-arm64 linux-x64 linux-arm64 osx-arm64; do
+          cp staging/"libllvmsharp-native-${rid}"/* "packages/libLLVMSharp/libLLVMSharp.runtime.${rid}/"
+          nuget pack "packages/libLLVMSharp/libLLVMSharp.runtime.${rid}/libLLVMSharp.runtime.${rid}.nuspec" -OutputDirectory out
+        done
+        nuget pack "packages/libLLVMSharp/libLLVMSharp/libLLVMSharp.nuspec" -OutputDirectory out
+    - uses: actions/upload-artifact@v4
+      with:
+        name: libLLVMSharp-packages
+        path: out/*.nupkg
+        if-no-files-found: error
+
+  # -------- sign the native packages (separate leg, native-specific file list) --------
+
+  sign-nuget:
+    needs: [ libllvm-pack, libllvmsharp-pack ]
+    # Sign on pushes to main whenever the legs that actually ran succeeded. A leg that
+    # was version-gated out is 'skipped' (not a failure), so a libLLVMSharp-only
+    # regeneration still gets signed; a real failure or cancellation blocks signing.
+    if: >-
+      ${{ github.event_name == 'push'
+          && !cancelled()
+          && needs.libllvm-pack.result != 'failure'
+          && needs.libllvmsharp-pack.result != 'failure'
+          && (needs.libllvm-pack.result == 'success' || needs.libllvmsharp-pack.result == 'success') }}
+    runs-on: windows-latest
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
+      with:
+        merge-multiple: true
+        path: ./artifacts/pkg
+        pattern: "lib*-packages"
+    - uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: ./global.json
+    - run: dotnet tool install --tool-path ./artifacts/tools --prerelease sign
+    - uses: azure/login@v2
+      with:
+        allow-no-subscriptions: true
+        client-id: "${{ secrets.AZURE_CLIENT_ID }}"
+        tenant-id: "${{ secrets.AZURE_TENANT_ID }}"
+    - run: ./artifacts/tools/sign code azure-key-vault "**/*.nupkg" --base-directory "${{ github.workspace }}/artifacts/pkg" --file-list "${{ github.workspace }}/scripts/SignClientFileListNative.txt" --publisher-name ".NET Foundation" --description "LLVMSharp" --description-url "https://github.com/dotnet/llvmsharp" --azure-credential-type "azure-cli" --azure-key-vault-url "${{ secrets.KEY_VAULT_URL }}" --azure-key-vault-certificate "${{ secrets.KEY_VAULT_CERTIFICATE_ID }}"
+      shell: pwsh
+    - uses: actions/upload-artifact@v4
+      with:
+        name: sign_nuget_native
+        path: |
+          ./artifacts/pkg/**/*
+        if-no-files-found: error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
 
-project(LLVMSharp VERSION 20.1.2)
+project(LLVMSharp VERSION 21.1.8)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Source browsing is available via: https://source.clangsharp.dev/
 * [License](#license)
 * [Features](#features)
 * [Building LLVMSharp](#building-llvmsharp)
+* [Regenerating native binaries](#regenerating-native-binaries)
 
 ### Code of Conduct
 
@@ -57,3 +58,32 @@ On Windows using .NET Core
  :> cd LLVMSharp
  :> dotnet build
 ```
+
+### Regenerating native binaries
+
+The native runtime packages are produced by CI (`.github/workflows/regenerate-native.yml`) rather than by hand:
+
+* `libLLVM.runtime.*` (and the `libLLVM` meta-package) — the prebuilt shared `libLLVM` library.
+* `libLLVMSharp.runtime.*` (and the `libLLVMSharp` meta-package) — the `libLLVMSharp` helper, compiled from `sources/libLLVMSharp` against the matching LLVM release.
+
+The tracked LLVM version is the `project(LLVMSharp VERSION X.Y.Z)` value in the top-level `CMakeLists.txt`, which maps to the `llvmorg-X.Y.Z` release tag. For each runtime (`win-x64`, `win-arm64`, `linux-x64`, `linux-arm64`, `osx-arm64`) the download-and-stage step is handled by `scripts/build.ps1`/`scripts/build.sh`:
+
+```
+# lift the prebuilt libLLVM (win-* on Windows)
+./scripts/build.ps1 -regeneratenative -target libLLVM -rid win-x64
+
+# lift the prebuilt libLLVM (linux-*/osx-* on the matching runner)
+./scripts/build.sh --regeneratenative --target libLLVM --rid linux-x64
+
+# compile libLLVMSharp against the matching LLVM release
+./scripts/build.sh --regeneratenative --target libLLVMSharp --rid linux-x64
+```
+
+The staged binary is written to `artifacts/native/<rid>/`. Unlike ClangSharp — which lifts the shared `libclang` that ships for every platform — the official LLVM releases only ship a shared `libLLVM` on Windows (as `LLVM-C.dll`, shipped under that official name). The managed resolver in `sources/LLVMSharp.Interop/LLVM.cs` maps the logical `libLLVM` P/Invoke name to the per-platform file (`LLVM-C.dll` on Windows; `libLLVM.so`/`libLLVM.dylib` elsewhere), which is also why `libLLVMSharp.dll`'s static `LLVM-C.dll` import resolves without an extra copy. Linux and macOS are lifted from the most-official prebuilt source per platform: [apt.llvm.org](https://apt.llvm.org/) (the LLVM project's own Debian/Ubuntu repository, `libllvm<major>`) on Linux and [Homebrew](https://formulae.brew.sh/formula/llvm) (`llvm`) on macOS, both of which link the standard system C++ runtime. `libLLVMSharp` is compiled per-runtime against the LLVM release distribution, which bundles the `lib/cmake/{llvm,clang}` config, headers, and import libraries used as `PATH_TO_LLVM`, so no from-source LLVM build is required.
+
+The jobs run when:
+
+* **libLLVM** — the tracked LLVM major/minor version changes, or the workflow is dispatched manually with the `libllvm` input set.
+* **libLLVMSharp** — the same LLVM version change, or anything under `sources/libLLVMSharp/` changes, or the workflow is dispatched manually with the `libllvmsharp` input set.
+
+Before anything is downloaded, the workflow verifies the `packages/**/*.nuspec` and `packages/**/runtime.json` versions match the tracked LLVM version (libLLVM exactly; libLLVMSharp as `<llvm-version>.<revision>`), so a version bump that forgot to update a package fails fast. Each job uploads the resulting `.nupkg` files as build artifacts and signs them; publishing them to NuGet.org is a manual step. To move to a new LLVM release, bump the version in `CMakeLists.txt` alongside the `<version>` in the affected `packages/**/*.nuspec` files (and the versions in `packages/**/runtime.json` and this README); pushing that change regenerates the packages.

--- a/packages/libLLVM/libLLVM.runtime.linux-arm64/libLLVM.runtime.linux-arm64.nuspec
+++ b/packages/libLLVM/libLLVM.runtime.linux-arm64/libLLVM.runtime.linux-arm64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libLLVM.runtime.linux-arm64</id>
-    <version>20.1.2</version>
+    <version>21.1.8</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/dotnet/llvmsharp</projectUrl>
     <description>linux arm64 native library for libLLVM.</description>
     <copyright>Copyright © LLVM Project</copyright>
-    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-20.1.2" />
+    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-21.1.8" />
   </metadata>
   <files>
     <file src="..\libLLVM\LICENSE.TXT" target="LICENSE.TXT" />

--- a/packages/libLLVM/libLLVM.runtime.linux-x64/libLLVM.runtime.linux-x64.nuspec
+++ b/packages/libLLVM/libLLVM.runtime.linux-x64/libLLVM.runtime.linux-x64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libLLVM.runtime.linux-x64</id>
-    <version>20.1.2</version>
+    <version>21.1.8</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/dotnet/llvmsharp</projectUrl>
     <description>linux x64 native library for libLLVM.</description>
     <copyright>Copyright © LLVM Project</copyright>
-    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-20.1.2" />
+    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-21.1.8" />
   </metadata>
   <files>
     <file src="..\libLLVM\LICENSE.TXT" target="LICENSE.TXT" />

--- a/packages/libLLVM/libLLVM.runtime.osx-arm64/libLLVM.runtime.osx-arm64.nuspec
+++ b/packages/libLLVM/libLLVM.runtime.osx-arm64/libLLVM.runtime.osx-arm64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libLLVM.runtime.osx-arm64</id>
-    <version>20.1.2</version>
+    <version>21.1.8</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/dotnet/llvmsharp</projectUrl>
     <description>osx arm64 native library for libLLVM.</description>
     <copyright>Copyright © LLVM Project</copyright>
-    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-20.1.2" />
+    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-21.1.8" />
   </metadata>
   <files>
     <file src="..\libLLVM\LICENSE.TXT" target="LICENSE.TXT" />

--- a/packages/libLLVM/libLLVM.runtime.win-arm64/libLLVM.runtime.win-arm64.nuspec
+++ b/packages/libLLVM/libLLVM.runtime.win-arm64/libLLVM.runtime.win-arm64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libLLVM.runtime.win-arm64</id>
-    <version>20.1.2</version>
+    <version>21.1.8</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -10,10 +10,10 @@
     <projectUrl>https://github.com/dotnet/llvmsharp</projectUrl>
     <description>win arm64 native library for libLLVM.</description>
     <copyright>Copyright © LLVM Project</copyright>
-    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-20.1.2" />
+    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-21.1.8" />
   </metadata>
   <files>
     <file src="..\libLLVM\LICENSE.TXT" target="LICENSE.TXT" />
-    <file src="libLLVM.dll" target="runtimes\win-arm64\native\libLLVM.dll" />
+    <file src="LLVM-C.dll" target="runtimes\win-arm64\native\LLVM-C.dll" />
   </files>
 </package>

--- a/packages/libLLVM/libLLVM.runtime.win-x64/libLLVM.runtime.win-x64.nuspec
+++ b/packages/libLLVM/libLLVM.runtime.win-x64/libLLVM.runtime.win-x64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libLLVM.runtime.win-x64</id>
-    <version>20.1.2</version>
+    <version>21.1.8</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -10,10 +10,10 @@
     <projectUrl>https://github.com/dotnet/llvmsharp</projectUrl>
     <description>win x64 native library for libLLVM.</description>
     <copyright>Copyright © LLVM Project</copyright>
-    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-20.1.2" />
+    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-21.1.8" />
   </metadata>
   <files>
     <file src="..\libLLVM\LICENSE.TXT" target="LICENSE.TXT" />
-    <file src="libLLVM.dll" target="runtimes\win-x64\native\libLLVM.dll" />
+    <file src="LLVM-C.dll" target="runtimes\win-x64\native\LLVM-C.dll" />
   </files>
 </package>

--- a/packages/libLLVM/libLLVM/libLLVM.nuspec
+++ b/packages/libLLVM/libLLVM/libLLVM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libLLVM</id>
-    <version>20.1.2</version>
+    <version>21.1.8</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/dotnet/llvmsharp</projectUrl>
     <description>Multi-platform native library for libLLVM.</description>
     <copyright>Copyright © LLVM Project</copyright>
-    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-20.1.2" />
+    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-21.1.8" />
     <dependencies>
       <group targetFramework=".NETStandard2.0" />
     </dependencies>

--- a/packages/libLLVM/libLLVM/runtime.json
+++ b/packages/libLLVM/libLLVM/runtime.json
@@ -2,27 +2,27 @@
   "runtimes": {
     "linux-arm64": {
       "libLLVM": {
-        "libLLVM.runtime.linux-arm64": "20.1.2"
+        "libLLVM.runtime.linux-arm64": "21.1.8"
       }
     },
     "linux-x64": {
       "libLLVM": {
-        "libLLVM.runtime.linux-x64": "20.1.2"
+        "libLLVM.runtime.linux-x64": "21.1.8"
       }
     },
     "osx-arm64": {
       "libLLVM": {
-        "libLLVM.runtime.osx-arm64": "20.1.2"
+        "libLLVM.runtime.osx-arm64": "21.1.8"
       }
     },
     "win-arm64": {
       "libLLVM": {
-        "libLLVM.runtime.win-arm64": "20.1.2"
+        "libLLVM.runtime.win-arm64": "21.1.8"
       }
     },
     "win-x64": {
       "libLLVM": {
-        "libLLVM.runtime.win-x64": "20.1.2"
+        "libLLVM.runtime.win-x64": "21.1.8"
       }
     }
   }

--- a/packages/libLLVMSharp/libLLVMSharp.runtime.linux-arm64/libLLVMSharp.runtime.linux-arm64.nuspec
+++ b/packages/libLLVMSharp/libLLVMSharp.runtime.linux-arm64/libLLVMSharp.runtime.linux-arm64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libLLVMSharp.runtime.linux-arm64</id>
-    <version>20.1.2</version>
+    <version>21.1.8.1</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/packages/libLLVMSharp/libLLVMSharp.runtime.linux-x64/libLLVMSharp.runtime.linux-x64.nuspec
+++ b/packages/libLLVMSharp/libLLVMSharp.runtime.linux-x64/libLLVMSharp.runtime.linux-x64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libLLVMSharp.runtime.linux-x64</id>
-    <version>20.1.2</version>
+    <version>21.1.8.1</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/packages/libLLVMSharp/libLLVMSharp.runtime.osx-arm64/libLLVMSharp.runtime.osx-arm64.nuspec
+++ b/packages/libLLVMSharp/libLLVMSharp.runtime.osx-arm64/libLLVMSharp.runtime.osx-arm64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libLLVMSharp.runtime.osx-arm64</id>
-    <version>20.1.2</version>
+    <version>21.1.8.1</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/packages/libLLVMSharp/libLLVMSharp.runtime.win-arm64/libLLVMSharp.runtime.win-arm64.nuspec
+++ b/packages/libLLVMSharp/libLLVMSharp.runtime.win-arm64/libLLVMSharp.runtime.win-arm64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libLLVMSharp.runtime.win-arm64</id>
-    <version>20.1.2</version>
+    <version>21.1.8.1</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/packages/libLLVMSharp/libLLVMSharp.runtime.win-x64/libLLVMSharp.runtime.win-x64.nuspec
+++ b/packages/libLLVMSharp/libLLVMSharp.runtime.win-x64/libLLVMSharp.runtime.win-x64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libLLVMSharp.runtime.win-x64</id>
-    <version>20.1.2</version>
+    <version>21.1.8.1</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/packages/libLLVMSharp/libLLVMSharp/libLLVMSharp.nuspec
+++ b/packages/libLLVMSharp/libLLVMSharp/libLLVMSharp.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libLLVMSharp</id>
-    <version>20.1.2</version>
+    <version>21.1.8.1</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/packages/libLLVMSharp/libLLVMSharp/runtime.json
+++ b/packages/libLLVMSharp/libLLVMSharp/runtime.json
@@ -2,27 +2,27 @@
   "runtimes": {
     "linux-arm64": {
       "libLLVMSharp": {
-        "libLLVMSharp.runtime.linux-arm64": "20.1.2"
+        "libLLVMSharp.runtime.linux-arm64": "21.1.8.1"
       }
     },
     "linux-x64": {
       "libLLVMSharp": {
-        "libLLVMSharp.runtime.linux-x64": "20.1.2"
+        "libLLVMSharp.runtime.linux-x64": "21.1.8.1"
       }
     },
     "osx-arm64": {
       "libLLVMSharp": {
-        "libLLVMSharp.runtime.osx-arm64": "20.1.2"
+        "libLLVMSharp.runtime.osx-arm64": "21.1.8.1"
       }
     },
     "win-arm64": {
       "libLLVMSharp": {
-        "libLLVMSharp.runtime.win-arm64": "20.1.2"
+        "libLLVMSharp.runtime.win-arm64": "21.1.8.1"
       }
     },
     "win-x64": {
       "libLLVMSharp": {
-        "libLLVMSharp.runtime.win-x64": "20.1.2"
+        "libLLVMSharp.runtime.win-x64": "21.1.8.1"
       }
     }
   }

--- a/scripts/SignClientFileListNative.txt
+++ b/scripts/SignClientFileListNative.txt
@@ -1,0 +1,2 @@
+**/LLVM-C.dll
+**/libLLVMSharp.dll

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -5,9 +5,13 @@ Param(
   [switch] $ci,
   [ValidateSet("Debug", "Release")][string] $configuration = "Debug",
   [switch] $help,
+  [string] $llvm = "",
   [switch] $pack,
+  [switch] $regeneratenative,
   [switch] $restore,
+  [ValidateSet("", "win-x64", "win-arm64", "linux-x64", "linux-arm64", "osx-arm64")][string] $rid = "",
   [string] $solution = "",
+  [ValidateSet("", "libLLVM", "libLLVMSharp")][string] $target = "",
   [switch] $test,
   [ValidateSet("quiet", "minimal", "normal", "detailed", "diagnostic")][string] $verbosity = "minimal",
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
@@ -43,6 +47,8 @@ function Help() {
     Write-Host -Object "  -build                  Build solution"
     Write-Host -Object "  -test                   Run all tests in the solution"
     Write-Host -Object "  -pack                   Package build artifacts"
+    Write-Host -Object "  -regeneratenative       Download the matching LLVM release and stage a native binary"
+    Write-Host -Object "                          (use with -target and -rid)"
     Write-Host -Object ""
     Write-Host -Object "Advanced settings:"
     Write-Host -Object "  -solution <value>       Path to solution to build"
@@ -78,6 +84,127 @@ function Restore() {
 
   if ($LastExitCode -ne 0) {
     throw "'Restore' failed for '$solution'"
+  }
+}
+
+function Get-LlvmVersion() {
+  if ($llvm -ne "") {
+    return $llvm
+  }
+
+  $cmakeLists = Join-Path -Path $RepoRoot -ChildPath "CMakeLists.txt"
+  $match = Select-String -Path $cmakeLists -Pattern 'project\(LLVMSharp VERSION ([0-9.]+)\)' | Select-Object -First 1
+
+  if (-not $match) {
+    throw "Could not parse the LLVM version from '$cmakeLists'"
+  }
+
+  return $match.Matches[0].Groups[1].Value
+}
+
+function Download-Llvm([string] $version, [string] $runtime, [string] $destination) {
+  $asset = switch ($runtime) {
+    "win-x64"     { "clang+llvm-$version-x86_64-pc-windows-msvc.tar.xz" }
+    "win-arm64"   { "clang+llvm-$version-aarch64-pc-windows-msvc.tar.xz" }
+    "linux-x64"   { "LLVM-$version-Linux-X64.tar.xz" }
+    "linux-arm64" { "LLVM-$version-Linux-ARM64.tar.xz" }
+    "osx-arm64"   { "LLVM-$version-macOS-ARM64.tar.xz" }
+    default       { throw "Unsupported runtime identifier '$runtime'" }
+  }
+
+  $url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-$version/$asset"
+  $archive = Join-Path -Path $ArtifactsDir -ChildPath "llvm-$runtime.tar.xz"
+
+  Create-Directory -Path $destination
+
+  # Windows ships bsdtar (libarchive) as tar.exe, which handles .tar.xz.
+  & curl.exe -fSL $url -o $archive
+
+  if ($LastExitCode -ne 0) {
+    throw "'curl' failed to download '$url'"
+  }
+
+  & tar -xf $archive -C $destination --strip-components=1
+
+  if ($LastExitCode -ne 0) {
+    throw "'tar' failed to extract '$archive'"
+  }
+}
+
+function Extract-LibLLVM([string] $runtime, [string] $source, [string] $destination) {
+  # The Windows LLVM release ships the C API shared library under its official name,
+  # 'LLVM-C.dll', which is the name the managed resolver in LLVM.cs loads and the name
+  # 'libLLVMSharp.dll' imports -- so it is shipped as-is, without renaming. The Linux/macOS
+  # releases ship no shared libLLVM (only static archives), so those runtimes are lifted
+  # from apt.llvm.org/Homebrew in build.sh instead.
+  if ($runtime -notlike "win-*") {
+    throw "'$runtime' cannot lift libLLVM here; use build.sh on the matching runner"
+  }
+
+  $lib = Get-ChildItem -Recurse -Path $source -Filter "LLVM-C.dll" -File | Sort-Object -Property "Length" -Descending | Select-Object -First 1
+
+  if (-not $lib) {
+    throw "'LLVM-C.dll' was not found in the LLVM release for '$runtime'"
+  }
+
+  Copy-Item -Path $lib.FullName -Destination (Join-Path -Path $destination -ChildPath "LLVM-C.dll")
+}
+
+function Build-LibLLVMSharp([string] $runtime, [string] $source, [string] $destination) {
+  $arch = switch ($runtime) {
+    "win-x64"   { "x64" }
+    "win-arm64" { "ARM64" }
+    default     { throw "'$runtime' cannot build libLLVMSharp on Windows; use build.sh on the matching runner" }
+  }
+
+  $nativeBuildDir = Join-Path -Path $ArtifactsDir -ChildPath "bin\native\$runtime"
+  $pathToLlvm = (Resolve-Path -Path $source).Path
+
+  & cmake -B "$nativeBuildDir" -S "$RepoRoot" -G "Visual Studio 17 2022" -A "$arch" "-Thost=$arch" "-DPATH_TO_LLVM=$pathToLlvm"
+
+  if ($LastExitCode -ne 0) {
+    throw "'cmake' configure failed for '$runtime'"
+  }
+
+  & cmake --build "$nativeBuildDir" --config Release --target LLVMSharp
+
+  if ($LastExitCode -ne 0) {
+    throw "'cmake' build failed for '$runtime'"
+  }
+
+  $lib = Get-ChildItem -Recurse -Path $nativeBuildDir -Filter "libLLVMSharp.dll" -File | Select-Object -First 1
+
+  if (-not $lib) {
+    throw "'libLLVMSharp.dll' was not produced for '$runtime'"
+  }
+
+  Copy-Item -Path $lib.FullName -Destination (Join-Path -Path $destination -ChildPath "libLLVMSharp.dll")
+}
+
+function Regenerate-Native() {
+  if ($rid -eq "") {
+    throw "-rid is required with -regeneratenative"
+  }
+
+  if ($target -eq "") {
+    throw "-target is required with -regeneratenative"
+  }
+
+  $version = Get-LlvmVersion
+  $llvmDir = Join-Path -Path $ArtifactsDir -ChildPath "llvm\$rid"
+  $stagingDir = Join-Path -Path $ArtifactsDir -ChildPath "native\$rid"
+
+  Download-Llvm -version "$version" -runtime "$rid" -destination "$llvmDir"
+  Create-Directory -Path $stagingDir
+
+  if ($target -eq "libLLVM") {
+    Extract-LibLLVM -runtime "$rid" -source "$llvmDir" -destination "$stagingDir"
+  }
+  elseif ($target -eq "libLLVMSharp") {
+    Build-LibLLVMSharp -runtime "$rid" -source "$llvmDir" -destination "$stagingDir"
+  }
+  else {
+    throw "Unsupported target '$target'"
   }
 }
 
@@ -152,6 +279,10 @@ try {
 
   if ($pack) {
     Pack
+  }
+
+  if ($regeneratenative) {
+    Regenerate-Native
   }
 }
 catch {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,9 +13,13 @@ build=false
 ci=false
 configuration='Debug'
 help=false
+llvm=''
 pack=false
+regeneratenative=false
 restore=false
+rid=''
 solution=''
+target=''
 test=false
 verbosity='minimal'
 properties=''
@@ -43,16 +47,32 @@ while [[ $# -gt 0 ]]; do
       help=true
       shift 1
       ;;
+    --llvm)
+      llvm=$2
+      shift 2
+      ;;
     --pack)
       pack=true
+      shift 1
+      ;;
+    --regeneratenative)
+      regeneratenative=true
       shift 1
       ;;
     --restore)
       restore=true
       shift 1
       ;;
+    --rid)
+      rid=$2
+      shift 2
+      ;;
     --solution)
       solution=$2
+      shift 2
+      ;;
+    --target)
+      target=$2
       shift 2
       ;;
     --test)
@@ -105,6 +125,8 @@ function Help {
   echo "  --build                   Build solution"
   echo "  --test                    Run all tests in the solution"
   echo "  --pack                    Package build artifacts"
+  echo "  --regeneratenative        Stage a native binary from the matching LLVM release"
+  echo "                            (use with --target and --rid)"
   echo ""
   echo "Advanced settings:"
   echo "  --solution <value>        Path to solution to build"
@@ -162,6 +184,230 @@ function Restore {
 
   if [ "$LASTEXITCODE" != 0 ]; then
     echo "'Restore' failed for '$solution'"
+    return "$LASTEXITCODE"
+  fi
+}
+
+function GetLlvmVersion {
+  if [[ -n "$llvm" ]]; then
+    LASTEXITCODE=0
+    return
+  fi
+
+  llvm="$(sed -n 's/^project(LLVMSharp VERSION \([0-9.]*\)).*/\1/p' "$RepoRoot/CMakeLists.txt")"
+
+  if [[ -z "$llvm" ]]; then
+    echo "Could not parse the LLVM version from '$RepoRoot/CMakeLists.txt'"
+    LASTEXITCODE=1
+    return "$LASTEXITCODE"
+  fi
+
+  LASTEXITCODE=0
+}
+
+function DownloadLlvm {
+  runtime="$1"
+  destination="$2"
+
+  case "$runtime" in
+    win-x64)     asset="clang+llvm-${llvm}-x86_64-pc-windows-msvc.tar.xz" ;;
+    win-arm64)   asset="clang+llvm-${llvm}-aarch64-pc-windows-msvc.tar.xz" ;;
+    linux-x64)   asset="LLVM-${llvm}-Linux-X64.tar.xz" ;;
+    linux-arm64) asset="LLVM-${llvm}-Linux-ARM64.tar.xz" ;;
+    osx-arm64)   asset="LLVM-${llvm}-macOS-ARM64.tar.xz" ;;
+    *)
+      echo "Unsupported runtime identifier '$runtime'"
+      LASTEXITCODE=1
+      return "$LASTEXITCODE"
+      ;;
+  esac
+
+  url="https://github.com/llvm/llvm-project/releases/download/llvmorg-${llvm}/${asset}"
+  archive="$ArtifactsDir/llvm-${runtime}.tar.xz"
+
+  CreateDirectory "$destination"
+
+  curl -fSL "$url" -o "$archive"
+  LASTEXITCODE=$?
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    echo "'curl' failed to download '$url'"
+    return "$LASTEXITCODE"
+  fi
+
+  tar -xf "$archive" -C "$destination" --strip-components=1
+  LASTEXITCODE=$?
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    echo "'tar' failed to extract '$archive'"
+    return "$LASTEXITCODE"
+  fi
+}
+
+function LiftLibLLVM {
+  runtime="$1"
+  destination="$2"
+  major="${llvm%%.*}"
+
+  # The official LLVM releases ship no shared libLLVM on Linux/macOS (only static
+  # archives), so lift it from the most-official prebuilt source per platform: the
+  # LLVM project's apt.llvm.org repository on Linux and Homebrew on macOS. Windows'
+  # LLVM-C.dll is lifted from the official release in build.ps1 instead.
+  case "$runtime" in
+    linux-*)
+      codename="$(. /etc/os-release && echo "$VERSION_CODENAME")"
+      wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
+      echo "deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${major} main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null
+      sudo apt-get update
+
+      downloadDir="$ArtifactsDir/apt/$runtime"
+      CreateDirectory "$downloadDir"
+      ( cd "$downloadDir" && apt-get download "libllvm${major}" )
+      LASTEXITCODE=$?
+
+      if [ "$LASTEXITCODE" != 0 ]; then
+        echo "'apt-get download libllvm${major}' failed for '$runtime'"
+        return "$LASTEXITCODE"
+      fi
+
+      deb="$(find "$downloadDir" -name "libllvm${major}_*.deb" | head -n1)"
+
+      if [[ -z "$deb" ]]; then
+        echo "'libllvm${major}' package was not downloaded for '$runtime'"
+        LASTEXITCODE=1
+        return "$LASTEXITCODE"
+      fi
+
+      dpkg-deb -x "$deb" "$downloadDir/extract"
+      src="$(find "$downloadDir/extract" -name 'libLLVM*.so*' -type f | head -n1)"
+      ;;
+    osx-*)
+      brew install "llvm@${major}" || brew install llvm
+      prefix="$(brew --prefix "llvm@${major}" 2> /dev/null || brew --prefix llvm)"
+      # The 'brew install llvm' fallback (used when 'llvm@${major}' is unavailable) can
+      # pull a different major; verify it matches the tracked version before packaging.
+      installedMajor="$("$prefix/bin/llvm-config" --version 2> /dev/null | cut -d. -f1)"
+      if [[ "$installedMajor" != "$major" ]]; then
+        echo "Homebrew provided LLVM major '$installedMajor' but '$major' is required for '$runtime'"
+        LASTEXITCODE=1
+        return "$LASTEXITCODE"
+      fi
+      src="$prefix/lib/libLLVM.dylib"
+      ;;
+    *)
+      echo "'$runtime' cannot lift libLLVM here; use build.ps1 on the matching runner"
+      LASTEXITCODE=1
+      return "$LASTEXITCODE"
+      ;;
+  esac
+
+  case "$runtime" in
+    osx-*) name='libLLVM.dylib' ;;
+    *)     name='libLLVM.so' ;;
+  esac
+
+  if [[ -z "$src" ]] || [[ ! -f "$src" ]]; then
+    echo "'$name' was not found for '$runtime'"
+    LASTEXITCODE=1
+    return "$LASTEXITCODE"
+  fi
+
+  cp -L "$src" "$destination/$name"
+  LASTEXITCODE=$?
+}
+
+function BuildLibLLVMSharp {
+  runtime="$1"
+  source="$2"
+  destination="$3"
+
+  case "$runtime" in
+    linux-*|osx-*)
+      ;;
+    *)
+      echo "'$runtime' cannot build libLLVMSharp here; use build.ps1 on the matching runner"
+      LASTEXITCODE=1
+      return "$LASTEXITCODE"
+      ;;
+  esac
+
+  nativeBuildDir="$ArtifactsDir/bin/native/$runtime"
+
+  cmake -B "$nativeBuildDir" -S "$RepoRoot" -DCMAKE_BUILD_TYPE=Release -DPATH_TO_LLVM="$source"
+  LASTEXITCODE=$?
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    echo "'cmake' configure failed for '$runtime'"
+    return "$LASTEXITCODE"
+  fi
+
+  cmake --build "$nativeBuildDir" --target LLVMSharp
+  LASTEXITCODE=$?
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    echo "'cmake' build failed for '$runtime'"
+    return "$LASTEXITCODE"
+  fi
+
+  case "$runtime" in
+    osx-*) name='libLLVMSharp.dylib' ;;
+    *)     name='libLLVMSharp.so' ;;
+  esac
+
+  # CMake's VERSION/SOVERSION emit a versioned library plus an unversioned symlink, so
+  # copy the dereferenced contents to get a real file.
+  src="$(find "$nativeBuildDir" -name "$name" | head -n1)"
+
+  if [[ -z "$src" ]]; then
+    echo "'$name' was not produced for '$runtime'"
+    LASTEXITCODE=1
+    return "$LASTEXITCODE"
+  fi
+
+  cp -L "$src" "$destination/$name"
+  LASTEXITCODE=$?
+}
+
+function RegenerateNative {
+  if [[ -z "$rid" ]]; then
+    echo "--rid is required with --regeneratenative"
+    LASTEXITCODE=1
+    return "$LASTEXITCODE"
+  fi
+
+  if [[ -z "$target" ]]; then
+    echo "--target is required with --regeneratenative"
+    LASTEXITCODE=1
+    return "$LASTEXITCODE"
+  fi
+
+  GetLlvmVersion
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    return "$LASTEXITCODE"
+  fi
+
+  llvmDir="$ArtifactsDir/llvm/$rid"
+  stagingDir="$ArtifactsDir/native/$rid"
+
+  CreateDirectory "$stagingDir"
+
+  if [[ "$target" == "libLLVM" ]]; then
+    LiftLibLLVM "$rid" "$stagingDir"
+  elif [[ "$target" == "libLLVMSharp" ]]; then
+    DownloadLlvm "$rid" "$llvmDir"
+
+    if [ "$LASTEXITCODE" != 0 ]; then
+      return "$LASTEXITCODE"
+    fi
+
+    BuildLibLLVMSharp "$rid" "$llvmDir" "$stagingDir"
+  else
+    echo "Unsupported target '$target'"
+    LASTEXITCODE=1
+  fi
+
+  if [ "$LASTEXITCODE" != 0 ]; then
     return "$LASTEXITCODE"
   fi
 }
@@ -253,6 +499,14 @@ fi
 
 if $pack; then
   Pack
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    return "$LASTEXITCODE"
+  fi
+fi
+
+if $regeneratenative; then
+  RegenerateNative
 
   if [ "$LASTEXITCODE" != 0 ]; then
     return "$LASTEXITCODE"

--- a/sources/LLVMSharp.Interop/LLVM.cs
+++ b/sources/LLVMSharp.Interop/LLVM.cs
@@ -41,8 +41,8 @@ public static unsafe partial class LLVM
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            return NativeLibrary.TryLoad("libLLVM.so.20", assembly, searchPath, out nativeLibrary)
-                || NativeLibrary.TryLoad("libLLVM-20", assembly, searchPath, out nativeLibrary)
+            return NativeLibrary.TryLoad("libLLVM.so.21", assembly, searchPath, out nativeLibrary)
+                || NativeLibrary.TryLoad("libLLVM-21", assembly, searchPath, out nativeLibrary)
                 || NativeLibrary.TryLoad("libLLVM.so.1", assembly, searchPath, out nativeLibrary);
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
Ports ClangSharp's native-package regeneration machinery to LLVMSharp so the `libLLVM.runtime.*` and `libLLVMSharp.runtime.*` packages are produced by CI rather than by hand, and brings the tracked native LLVM version up to `21.1.8` to match the managed bindings (#251).

Two commits:
* **Bump tracked native LLVM version to 21.1.8** — `CMakeLists.txt` (`project(LLVMSharp VERSION ...)`, the source of truth), the `packages/libLLVM/**` (`21.1.8`) and `packages/libLLVMSharp/**` (`21.1.8.1`) nuspecs/`runtime.json`, and the Linux SONAMEs in the managed resolver (`LLVM.cs`, `libLLVM.so.20`/`libLLVM-20` → `21`).
* **Add native-package regeneration workflow** — `.github/workflows/regenerate-native.yml`, the `-regeneratenative` logic in `scripts/build.ps1`/`build.sh`, `scripts/SignClientFileListNative.txt`, and the README/copilot-instructions sections.

----------

**Key divergence from ClangSharp.** ClangSharp lifts the shared `libclang` that upstream ships for every platform. The official LLVM releases only ship a shared `libLLVM` on **Windows** (as `LLVM-C.dll`); the Linux/macOS releases are static-archive-only. So the `libLLVM` lift is per-platform and `libLLVM` runs as a native-runner matrix rather than ClangSharp's single-Windows-runner job:

* **Windows** — `LLVM-C.dll` from the official GitHub release, shipped under its official name.
* **Linux** — apt.llvm.org (`libllvm<major>`), the LLVM project's own Debian/Ubuntu repo.
* **macOS** — Homebrew (`llvm`).

`libLLVMSharp` compiles against the LLVM release distribution the same way ClangSharp's `libClangSharp` does, on every platform.

----------

**On the Windows naming** (this is where an earlier draft was wrong, thanks to review): the managed resolver in `LLVMSharp.Interop/LLVM.cs` already maps the logical `libLLVM` P/Invoke to the official per-platform file — `LLVM-C.dll` on Windows, `libLLVM.so`/`libLLVM.dylib` elsewhere. So the package ships `LLVM-C.dll` under its official name rather than renaming it to `libLLVM.dll`. This also matters because `libLLVMSharp.dll` links the `LLVM-C` import lib, so its PE import is `LLVM-C.dll` — renaming would have left that dependency unsatisfied. Shipping the official name keeps a single LLVM copy in-process with no extra resolver plumbing.

----------

**Gating.** `libLLVM` regenerates when the tracked LLVM version changes (full patch, since the package version is exact `21.1.8`); `libLLVMSharp` on that or any change under `sources/libLLVMSharp/`. Both are forceable via `workflow_dispatch`. `detect` verifies the nuspec/`runtime.json` versions match the tracked version before anything downloads, so a bump that forgot a package fails fast.

----------

**Caveats to flag:**
* The apt/Homebrew lifts, the per-platform helper build, and the workflow itself **can't be exercised locally** (Windows box, no CI) — scripts pass syntax checks only, so the first real run may need a follow-up tweak.
* Only Windows (GitHub release) and the managed bindings are pinned to exactly `21.1.8`; apt.llvm.org/Homebrew give the latest `21.1.x` patch. Acceptable for an ABI-stable shared runtime, but worth knowing. The macOS lift verifies the installed major matches before packaging (guards the `brew install llvm` fallback).

`dotnet build -c Release` is clean (0 warnings, `TreatWarningsAsErrors`) and all 2587 tests pass on `net10.0`. The managed build doesn't invoke CMake/nuspecs, so the infra changes don't affect it.

> [!NOTE]
> This PR body and the changes were drafted by Copilot at @tannergooding's direction.
