### PR TITLE
Bump hand-written interop headers to llvmorg-21.1.8

### DIFF
--- a/sources/LLVMSharp.Interop/Extensions/LLVM.Manual.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVM.Manual.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System;

--- a/sources/LLVMSharp.Interop/Manual/LLVMComdat.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMComdat.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMDiagnosticHandler.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMDiagnosticHandler.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System.Runtime.InteropServices;

--- a/sources/LLVMSharp.Interop/Manual/LLVMFatalErrorHandler.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMFatalErrorHandler.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System.Runtime.InteropServices;

--- a/sources/LLVMSharp.Interop/Manual/LLVMJITCSymbolMapPair.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMJITCSymbolMapPair.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMMemoryManagerAllocateCodeSectionCallback.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMMemoryManagerAllocateCodeSectionCallback.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System;

--- a/sources/LLVMSharp.Interop/Manual/LLVMMemoryManagerAllocateDataSectionCallback.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMMemoryManagerAllocateDataSectionCallback.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System;

--- a/sources/LLVMSharp.Interop/Manual/LLVMMemoryManagerDestroyCallback.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMMemoryManagerDestroyCallback.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System.Runtime.InteropServices;

--- a/sources/LLVMSharp.Interop/Manual/LLVMMemoryManagerFinalizeMemoryCallback.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMMemoryManagerFinalizeMemoryCallback.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System.Runtime.InteropServices;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpInfoCallback.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpInfoCallback.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System.Runtime.InteropServices;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueAttributeRef.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueAttributeRef.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueBasicBlock.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueBasicBlock.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueBinary.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueBinary.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueBuilder.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueBuilder.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueContext.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueContext.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueDIBuilder.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueDIBuilder.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueDbgRecord.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueDbgRecord.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueDiagnosticInfo.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueDiagnosticInfo.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueError.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueError.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueExecutionEngine.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueExecutionEngine.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueGenericValue.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueGenericValue.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueJITEventListener.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueJITEventListener.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueLTOCodeGenerator.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueLTOCodeGenerator.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueLTOInput.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueLTOInput.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueLTOModule.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueLTOModule.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueMCJITMemoryManager.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueMCJITMemoryManager.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueMemoryBuffer.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueMemoryBuffer.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueMetadata.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueMetadata.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueModule.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueModule.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueModuleFlagEntry.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueModuleFlagEntry.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueModuleProvider.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueModuleProvider.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueNamedMDNode.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueNamedMDNode.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueObjectFile.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueObjectFile.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueOperandBundle.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueOperandBundle.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaquePass.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaquePass.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaquePassBuilderOptions.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaquePassBuilderOptions.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaquePassManager.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaquePassManager.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaquePassRegistry.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaquePassRegistry.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueRelocationIterator.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueRelocationIterator.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueSectionIterator.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueSectionIterator.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueSymbolIterator.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueSymbolIterator.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueTargetData.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueTargetData.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueTargetLibraryInfotData.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueTargetLibraryInfotData.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueTargetMachine.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueTargetMachine.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueTargetMachineOptions.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueTargetMachineOptions.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueThinLTOCodeGenerator.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueThinLTOCodeGenerator.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueType.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueType.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueUse.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueUse.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOpaqueValue.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOpaqueValue.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcCAPIDefinitionGeneratorTryToGenerateFunction.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcCAPIDefinitionGeneratorTryToGenerateFunction.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcErrorReporterFunction.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcErrorReporterFunction.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System.Runtime.InteropServices;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcGenericIRModuleOperationFunction.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcGenericIRModuleOperationFunction.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System.Runtime.InteropServices;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcIRTransformLayerTransformFunction.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcIRTransformLayerTransformFunction.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System.Runtime.InteropServices;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcLLJITBuilderObjectLinkingLayerCreatorFunction.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcLLJITBuilderObjectLinkingLayerCreatorFunction.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System.Runtime.InteropServices;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcMaterializationUnitDestroyFunction.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcMaterializationUnitDestroyFunction.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System.Runtime.InteropServices;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcMaterializationUnitDiscardFunction.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcMaterializationUnitDiscardFunction.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System.Runtime.InteropServices;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcMaterializationUnitMaterializeFunction.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcMaterializationUnitMaterializeFunction.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System.Runtime.InteropServices;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcObjectTransformLayerTransformFunction.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcObjectTransformLayerTransformFunction.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System.Runtime.InteropServices;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueDefinitionGenerator.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueDefinitionGenerator.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueDumpObjects.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueDumpObjects.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueExecutionSession.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueExecutionSession.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueIRTransformLayer.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueIRTransformLayer.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueIndirectStubsManager.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueIndirectStubsManager.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueJITDylib.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueJITDylib.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueJITTargetMachineBuilder.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueJITTargetMachineBuilder.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueLLJIT.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueLLJIT.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueLLJITBuilder.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueLLJITBuilder.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueLazyCallThroughManager.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueLazyCallThroughManager.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueLookupState.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueLookupState.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueMaterializationResponsibility.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueMaterializationResponsibility.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueMaterializationUnit.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueMaterializationUnit.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueObjectLayer.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueObjectLayer.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueObjectTransformLayer.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueObjectTransformLayer.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueResourceTracker.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueResourceTracker.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueSymbolStringPool.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueSymbolStringPool.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueSymbolStringPoolEntry.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueSymbolStringPoolEntry.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueThreadSafeContext.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueThreadSafeContext.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueThreadSafeModule.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcOpaqueThreadSafeModule.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMOrcSymbolPredicate.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMOrcSymbolPredicate.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System.Runtime.InteropServices;

--- a/sources/LLVMSharp.Interop/Manual/LLVMRemarkOpaqueArg.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMRemarkOpaqueArg.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMRemarkOpaqueDebugLoc.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMRemarkOpaqueDebugLoc.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMRemarkOpaqueEntry.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMRemarkOpaqueEntry.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMRemarkOpaqueParser.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMRemarkOpaqueParser.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMRemarkOpaqueString.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMRemarkOpaqueString.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMSymbolLookupCallback.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMSymbolLookupCallback.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System.Runtime.InteropServices;

--- a/sources/LLVMSharp.Interop/Manual/LLVMTarget.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMTarget.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMValueMetadataEntry.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMValueMetadataEntry.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 namespace LLVMSharp.Interop;

--- a/sources/LLVMSharp.Interop/Manual/LLVMYieldCallback.cs
+++ b/sources/LLVMSharp.Interop/Manual/LLVMYieldCallback.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System.Runtime.InteropServices;

--- a/sources/LLVMSharp.Interop/Manual/lto_diagnostic_handler_t.cs
+++ b/sources/LLVMSharp.Interop/Manual/lto_diagnostic_handler_t.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-20.1.2/llvm/include/llvm-c
+// Ported from https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8/llvm/include/llvm-c
 // Original source is Copyright (c) the LLVM Project and Contributors. Licensed under the Apache License v2.0 with LLVM Exceptions. See NOTICE.txt in the project root for license information.
 
 using System.Runtime.InteropServices;


### PR DESCRIPTION
The generated `llvm/*` interop (and the native packages, as of #253) track `llvmorg-21.1.8`, but the hand-written ports under `sources/LLVMSharp.Interop/Manual/` and `Extensions/LLVM.Manual.cs` still carried `// Ported from .../llvmorg-20.1.2/...` headers. This bumps those 89 files to `llvmorg-21.1.8` so the whole tree is consistent and matches ClangSharp's convention (its hand-written `Manual/` headers track the current release).

Comment-only; no runtime or API effect. `dotnet build -c Release` is clean (0 warnings) and the tests are unaffected.

> [!NOTE]
> This PR body and the change were drafted by Copilot at @tannergooding's direction.