### PR TITLE
Fix native libLLVM resolver falling back to a system-installed libLLVM

### DIFF
--- a/sources/LLVMSharp.Interop/LLVM.cs
+++ b/sources/LLVMSharp.Interop/LLVM.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -14,6 +15,9 @@ public static unsafe partial class LLVM
 {
     public static event DllImportResolver? ResolveLibrary;
 
+    public const int MajorVersion = 21;
+    public const int MinorVersion = 1;
+
     static LLVM()
     {
         if (!Configuration.DisableResolveLibraryHook)
@@ -24,11 +28,19 @@ public static unsafe partial class LLVM
 
     private static IntPtr OnDllImport(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
     {
+        // Let user hooks attempt to resolve first, so they can override the behavior for their app
         if (TryResolveLibrary(libraryName, assembly, searchPath, out var nativeLibrary))
         {
             return nativeLibrary;
         }
 
+        // Then try the normal resolution of the library
+        if (TryResolve(libraryName, assembly, searchPath.GetValueOrDefault(), out nativeLibrary))
+        {
+            return nativeLibrary;
+        }
+
+        // Finally, do library specific resolution as applicable
         if (libraryName.Equals("libLLVM", StringComparison.Ordinal) && TryResolveLLVM(assembly, searchPath, out nativeLibrary))
         {
             return nativeLibrary;
@@ -37,20 +49,117 @@ public static unsafe partial class LLVM
         return IntPtr.Zero;
     }
 
+    private static bool TryResolve(string libraryName, Assembly assembly, DllImportSearchPath searchPath, out IntPtr nativeLibrary)
+    {
+        if (TryResolveFromAppDirectory(libraryName, assembly, searchPath, out nativeLibrary))
+        {
+            return true;
+        }
+
+        return NativeLibrary.TryLoad(libraryName, assembly, searchPath, out nativeLibrary);
+    }
+
     private static bool TryResolveLLVM(Assembly assembly, DllImportSearchPath? searchPath, out IntPtr nativeLibrary)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            return NativeLibrary.TryLoad("libLLVM.so.21", assembly, searchPath, out nativeLibrary)
-                || NativeLibrary.TryLoad("libLLVM-21", assembly, searchPath, out nativeLibrary)
-                || NativeLibrary.TryLoad("libLLVM.so.1", assembly, searchPath, out nativeLibrary);
+            return TryResolve($"libLLVM.so.{MajorVersion}", assembly, searchPath.GetValueOrDefault(), out nativeLibrary)
+                || TryResolve($"libLLVM-{MajorVersion}", assembly, searchPath.GetValueOrDefault(), out nativeLibrary)
+                || TryResolve("libLLVM.so.1", assembly, searchPath.GetValueOrDefault(), out nativeLibrary);
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            return NativeLibrary.TryLoad("LLVM-C.dll", assembly, searchPath, out nativeLibrary);
+            return TryResolve("LLVM-C.dll", assembly, searchPath.GetValueOrDefault(), out nativeLibrary);
         }
 
         nativeLibrary = IntPtr.Zero;
+        return false;
+    }
+
+    private static bool TryResolveFromAppDirectory(string libraryName, Assembly assembly, DllImportSearchPath searchPath, out IntPtr nativeLibrary)
+    {
+        nativeLibrary = default;
+
+        // DllImportSearchPath is ignored on non-Windows and the default resolution
+        // algorithm does not look in the application directory.
+        // We need to look here for any dependencies that are shipped SxS with the
+        // application, using the standard variations allowed.
+        if (OperatingSystem.IsWindows())
+        {
+            return false;
+        }
+
+        if ((searchPath & (DllImportSearchPath.SafeDirectories | DllImportSearchPath.ApplicationDirectory)) == 0)
+        {
+            return false;
+        }
+
+        if (Path.IsPathFullyQualified(libraryName))
+        {
+            return false;
+        }
+
+        // We use Environment.ProcessPath because that is the location of the executable
+        // that launched the process. AppContext.BaseDirectory can be overridden and is
+        // rather more the "AssemblyDirectory". This is a subtle distinction, but an important one.
+        var applicationDirectory = Path.GetDirectoryName(Environment.ProcessPath);
+
+        if (applicationDirectory is null)
+        {
+            return false;
+        }
+
+        var libraryPath = Path.Combine(applicationDirectory, libraryName);
+
+        if (NativeLibrary.TryLoad(libraryPath, assembly, searchPath, out nativeLibrary))
+        {
+            return true;
+        }
+
+        // We try the given name first, as that is always preferred. Then we try, in order:
+        //   * libname
+        //   * name.ext
+        //   * libname.ext
+        //
+        // This can result in some redundant lookups, but it's how the built-in logic works
+        // for non-relative paths.
+        var prefixedLibraryName = "";
+
+        if (!libraryName.Contains(Path.DirectorySeparatorChar, StringComparison.Ordinal))
+        {
+            prefixedLibraryName = $"lib{libraryName}";
+            libraryPath = Path.Combine(applicationDirectory, prefixedLibraryName);
+
+            if (NativeLibrary.TryLoad(libraryPath, assembly, searchPath, out nativeLibrary))
+            {
+                return true;
+            }
+        }
+
+        var extension = ".so";
+
+        if (OperatingSystem.IsMacOS() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS())
+        {
+            extension = ".dylib";
+        }
+
+        libraryPath = Path.Combine(applicationDirectory, $"{libraryName}{extension}");
+
+        if (NativeLibrary.TryLoad(libraryPath, assembly, searchPath, out nativeLibrary))
+        {
+            return true;
+        }
+
+        if (prefixedLibraryName.Length != 0)
+        {
+            libraryPath = Path.Combine(applicationDirectory, $"{prefixedLibraryName}{extension}");
+
+            if (NativeLibrary.TryLoad(libraryPath, assembly, searchPath, out nativeLibrary))
+            {
+                return true;
+            }
+        }
+
         return false;
     }
 


### PR DESCRIPTION
Fixes the `EntryPointNotFound` reports on Debian/Ubuntu in #226 (e.g. `LLVMInitializeLoongArchTargetInfo`).

## Root cause

Not a missing-target problem in the generated bindings — the six `InitializeAll*` aggregators in `sources/LLVMSharp.Interop/llvm/LLVM.cs` already enumerate the full 20-target list (including LoongArch), and the corresponding `[DllImport]`s in `Extensions/LLVM.Manual.cs` are all present.

The bug is in the native library resolver, `sources/LLVMSharp.Interop/LLVM.cs`:

1. **Stale hard-coded version number.** The Linux probe only tried `libLLVM.so.20`/`libLLVM-20`/`libLLVM.so.1` — a literal baked in at the last release touch. Every version bump leaves it stale (the reporter was on `18.1.6`; we're now on `21.1.8`, and #253 just had to hand-bump this exact literal `.so.20` → `.so.21` again).
2. **No app-directory / SxS probing.** When the versioned probe misses, resolution falls through to the CLR's default P/Invoke search, which on Linux does not search the app's own output directory. On Debian/Ubuntu boxes with a system LLVM/clang toolchain installed via `apt`, this can silently bind that system `libLLVM` instead of the NuGet-restored one next to the app — and that system build may be missing newer targets like LoongArch. Arch boxes typically don't have a conflicting system `libLLVM`, so the bug never surfaces there, matching the reporter's Arch-works/Debian-fails split.

## Fix

Ports the resolver pattern `ClangSharp` already uses for `libclang` (`sources/ClangSharp.Interop/clang.cs`):
- `MajorVersion`/`MinorVersion` constants tracked alongside the `libLLVM` package pin, replacing the hard-coded `20` literal.
- `TryResolveFromAppDirectory`, probing the application's own output directory (with standard `lib`-prefix/`.so`/`.dylib` name variations) before falling back to the OS-wide default search — so the SxS-restored `libLLVM` is always preferred over a system-installed one.

----------

Verified: `dotnet build -c Release` → 0 warnings/errors; `dotnet test -c Release --no-build` → 2587/2587 passing.

Note: `MajorVersion`/`MinorVersion` still need to be bumped by hand alongside `VersionPrefix`/the `libLLVM` package pin on every version bump (same as ClangSharp today) — no single source of truth wires them together automatically. Worth a follow-up if this keeps drifting, but out of scope here.

CC @tannergooding
