### PR TITLE
Add LLVMValueRef.GlobalValueType wrapping LLVMGlobalGetValueType

### DIFF
--- a/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
@@ -151,6 +151,8 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public readonly LLVMModuleRef GlobalParent => (IsAGlobalValue != null) ? LLVM.GetGlobalParent(this) : default;
 
+    public readonly LLVMTypeRef GlobalValueType => (IsAGlobalValue != null) ? LLVM.GlobalGetValueType(this) : default;
+
     public readonly LLVMMetadataRef GlobalVariableExpression => (IsAGlobalVariable != null) ? llvmsharp.GlobalVariable_getGlobalVariableExpression(this) : default;
 
     public readonly bool HasMetadata => (IsAInstruction != null) && LLVM.HasMetadata(this) != 0;

--- a/tests/LLVMSharp.UnitTests/Functions.cs
+++ b/tests/LLVMSharp.UnitTests/Functions.cs
@@ -28,4 +28,17 @@ public class Functions
         var attrs = functionValue.GetAttributesAtIndex((LLVMAttributeIndex)1);
         Assert.That((AttributeKind)attrs[0].KindAsEnum, Is.EqualTo(AttributeKind.ByVal));
     }
+
+    [Test]
+    public void GlobalValueTypeReturnsFunctionType()
+    {
+        var module = LLVMModuleRef.CreateWithName("Test Module");
+        var functionType = LLVMTypeRef.CreateFunction(LLVMTypeRef.Int32, [LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0)], IsVarArg: true);
+        var functionValue = module.AddFunction("printf", functionType);
+
+        // Under opaque pointers TypeOf is an opaque pointer, so callers need
+        // GlobalValueType to recover the actual function type for BuildCall2.
+        Assert.That(functionValue.TypeOf.Kind, Is.EqualTo(LLVMTypeKind.LLVMPointerTypeKind));
+        Assert.That(functionValue.GlobalValueType, Is.EqualTo(functionType));
+    }
 }


### PR DESCRIPTION
Under opaque pointers, a function value's `TypeOf` is an opaque `ptr`, so `BuildCall2` must be given the function type rather than the value's type. `LLVMGlobalGetValueType` exposes it but had no OO wrapper, which trips up common cases like calling `printf` where users reach for `func.TypeOf` and hit `Calling a function with a bad signature!`.

This adds a `GlobalValueType` property alongside the other `IsAGlobalValue`-guarded members, so the function type is recoverable without stashing it in a side dictionary.

Fixes #229.

----------

Test added covers the root cause directly: a function value's `TypeOf` is a pointer, where-as `GlobalValueType` returns the original function type. Full suite still passes.