### PR TITLE
Add OO wrappers for calling conventions and attributes

### DIFF
--- a/sources/LLVMSharp.Interop/Extensions/LLVMContextRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMContextRef.cs
@@ -84,6 +84,24 @@ public unsafe partial struct LLVMContextRef(IntPtr handle) : IDisposable, IEquat
         return LLVM.CreateEnumAttribute(this, KindId, Val);
     }
 
+    public static uint GetEnumAttributeKindForName(ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        return LLVM.GetEnumAttributeKindForName(marshaledName, (nuint)marshaledName.Length);
+    }
+
+    public readonly LLVMAttributeRef CreateEnumAttribute(ReadOnlySpan<char> Name, ulong Val)
+    {
+        return CreateEnumAttribute(GetEnumAttributeKindForName(Name), Val);
+    }
+
+    public readonly LLVMAttributeRef CreateStringAttribute(ReadOnlySpan<char> Kind, ReadOnlySpan<char> Value)
+    {
+        using var marshaledKind = new MarshaledString(Kind);
+        using var marshaledValue = new MarshaledString(Value);
+        return LLVM.CreateStringAttribute(this, marshaledKind, (uint)marshaledKind.Length, marshaledValue, (uint)marshaledValue.Length);
+    }
+
     public void Dispose()
     {
         if (Handle != IntPtr.Zero)

--- a/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
@@ -1067,6 +1067,10 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public readonly uint GetAttributeCountAtIndex(LLVMAttributeIndex Idx) => LLVM.GetAttributeCountAtIndex(this, Idx);
 
+    public readonly LLVMAttributeRef GetEnumAttributeAtIndex(LLVMAttributeIndex Idx, uint KindId) => LLVM.GetEnumAttributeAtIndex(this, Idx, KindId);
+
+    public readonly void RemoveEnumAttributeAtIndex(LLVMAttributeIndex Idx, uint KindId) => LLVM.RemoveEnumAttributeAtIndex(this, Idx, KindId);
+
     public readonly LLVMValueRef GetBlockAddress(LLVMBasicBlockRef BB) => LLVM.BlockAddress(this, BB);
 
     public readonly uint GetCallSiteAttributeCount(LLVMAttributeIndex Idx) => LLVM.GetCallSiteAttributeCount(this, Idx);

--- a/sources/LLVMSharp/Attribute.cs
+++ b/sources/LLVMSharp/Attribute.cs
@@ -7,7 +7,26 @@ namespace LLVMSharp;
 
 public sealed class Attribute : IEquatable<Attribute>
 {
+    internal Attribute(LLVMAttributeRef handle)
+    {
+        Handle = handle;
+    }
+
     public LLVMAttributeRef Handle { get; }
+
+    public bool IsEnumAttribute => Handle.IsEnumAttribute;
+
+    public bool IsStringAttribute => Handle.IsStringAttribute;
+
+    public bool IsTypeAttribute => Handle.IsTypeAttribute;
+
+    public uint KindAsEnum => Handle.KindAsEnum;
+
+    public string KindAsString => Handle.KindAsString;
+
+    public ulong ValueAsInt => Handle.ValueAsInt;
+
+    public string ValueAsString => Handle.ValueAsString;
 
     public static bool operator ==(Attribute? left, Attribute? right) => ReferenceEquals(left, right) || (left?.Handle == right?.Handle);
 

--- a/sources/LLVMSharp/LLVMContext.cs
+++ b/sources/LLVMSharp/LLVMContext.cs
@@ -19,6 +19,14 @@ public sealed class LLVMContext : IEquatable<LLVMContext>
 
     public LLVMContextRef Handle { get; }
 
+    public Attribute CreateEnumAttribute(uint kindId, ulong value) => new Attribute(Handle.CreateEnumAttribute(kindId, value));
+
+    public Attribute CreateEnumAttribute(ReadOnlySpan<char> name, ulong value) => new Attribute(Handle.CreateEnumAttribute(name, value));
+
+    public Attribute CreateStringAttribute(ReadOnlySpan<char> kind, ReadOnlySpan<char> value) => new Attribute(Handle.CreateStringAttribute(kind, value));
+
+    public static uint GetEnumAttributeKindForName(ReadOnlySpan<char> name) => LLVMContextRef.GetEnumAttributeKindForName(name);
+
     public static bool operator ==(LLVMContext? left, LLVMContext? right) => ReferenceEquals(left, right) || (left?.Handle == right?.Handle);
 
     public static bool operator !=(LLVMContext? left, LLVMContext? right) => !(left == right);

--- a/sources/LLVMSharp/Values/Users/Constants/GlobalValues/Function.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/GlobalValues/Function.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System;
 using LLVMSharp.Interop;
 
 namespace LLVMSharp;
@@ -9,4 +10,39 @@ public sealed class Function : GlobalObject
     internal Function(LLVMValueRef handle) : base(handle.IsAFunction, LLVMValueKind.LLVMFunctionValueKind)
     {
     }
+
+    public LLVMCallConv CallingConvention
+    {
+        get
+        {
+            return (LLVMCallConv)Handle.FunctionCallConv;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.FunctionCallConv = (uint)value;
+        }
+    }
+
+    public void AddAttributeAtIndex(LLVMAttributeIndex index, Attribute attribute)
+    {
+        ArgumentNullException.ThrowIfNull(attribute);
+        Handle.AddAttributeAtIndex(index, attribute.Handle);
+    }
+
+    public Attribute[] GetAttributesAtIndex(LLVMAttributeIndex index)
+    {
+        var handles = Handle.GetAttributesAtIndex(index);
+        var attributes = new Attribute[handles.Length];
+
+        for (var i = 0; i < handles.Length; i++)
+        {
+            attributes[i] = new Attribute(handles[i]);
+        }
+
+        return attributes;
+    }
+
+    public void RemoveEnumAttributeAtIndex(LLVMAttributeIndex index, uint kindId) => Handle.RemoveEnumAttributeAtIndex(index, kindId);
 }

--- a/sources/LLVMSharp/Values/Users/Instructions/CallBase.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/CallBase.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System;
 using LLVMSharp.Interop;
 
 namespace LLVMSharp;
@@ -8,5 +9,38 @@ public class CallBase : Instruction
 {
     private protected CallBase(LLVMValueRef handle) : base(handle)
     {
+    }
+
+    public LLVMCallConv CallingConvention
+    {
+        get
+        {
+            return (LLVMCallConv)Handle.InstructionCallConv;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.InstructionCallConv = (uint)value;
+        }
+    }
+
+    public void AddAttributeAtIndex(LLVMAttributeIndex index, Attribute attribute)
+    {
+        ArgumentNullException.ThrowIfNull(attribute);
+        Handle.AddAttributeAtIndex(index, attribute.Handle);
+    }
+
+    public Attribute[] GetAttributesAtIndex(LLVMAttributeIndex index)
+    {
+        var handles = Handle.GetCallSiteAttributes(index);
+        var attributes = new Attribute[handles.Length];
+
+        for (var i = 0; i < handles.Length; i++)
+        {
+            attributes[i] = new Attribute(handles[i]);
+        }
+
+        return attributes;
     }
 }


### PR DESCRIPTION
Surfaces the existing LLVM-C calling-convention and attribute interop on the hand-written OO layer, addressing #217.

- `Function.CallingConvention` and `CallBase.CallingConvention` (get/set, `LLVMCallConv`)
- `Function` attribute add/get plus `RemoveEnumAttributeAtIndex`; `CallBase` call-site attribute add/get
- `Attribute` made constructible with enum/string/type introspection (`IsEnumAttribute`, `KindAsEnum`, `KindAsString`, `ValueAsInt`, `ValueAsString`, ...)
- `LLVMContext` enum/string attribute factories and enum-kind lookup
- `LLVMContextRef` string/named attribute creation helpers and `LLVMValueRef` `Get`/`RemoveEnumAttributeAtIndex` passthroughs

All of this was already reachable at the interop layer (`LLVMValueRef.FunctionCallConv`/`InstructionCallConv`, `AddAttributeAtIndex`, `GetAttributesAtIndex`, `GetCallSiteAttributes`, `LLVMContextRef.CreateEnumAttribute`, full `LLVMCallConv` enum); the only gap was the hand-written OO surface plus a couple of string-attribute/enum-kind-lookup helpers.

Build is clean (0 warnings) and all 2587 tests pass.

Closes #217