### PR TITLE
Add OO replace/erase helpers for values and instructions

### DIFF
--- a/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
@@ -1147,6 +1147,8 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public readonly void InstructionEraseFromParent() => LLVM.InstructionEraseFromParent(this);
 
+    public readonly void InstructionRemoveFromParent() => LLVM.InstructionRemoveFromParent(this);
+
     public readonly string PrintToString()
     {
         var pStr = LLVM.PrintValueToString(this);

--- a/sources/LLVMSharp/Values/Users/Instructions/Instruction.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/Instruction.cs
@@ -10,6 +10,10 @@ public partial class Instruction : User
     {
     }
 
+    public void EraseFromParent() => Handle.InstructionEraseFromParent();
+
+    public void RemoveFromParent() => Handle.InstructionRemoveFromParent();
+
     internal static new Instruction Create(LLVMValueRef handle) => handle switch
     {
         _ when handle.IsAUnaryOperator != null => new UnaryOperator(handle),

--- a/sources/LLVMSharp/Values/Value.cs
+++ b/sources/LLVMSharp/Values/Value.cs
@@ -18,6 +18,12 @@ public class Value : IEquatable<Value>
 
     public LLVMValueRef Handle { get; }
 
+    public void ReplaceAllUsesWith(Value newValue)
+    {
+        ArgumentNullException.ThrowIfNull(newValue);
+        Handle.ReplaceAllUsesWith(newValue.Handle);
+    }
+
     public static bool operator ==(Value? left, Value? right) => ReferenceEquals(left, right) || (left?.Handle == right?.Handle);
 
     public static bool operator !=(Value? left, Value? right) => !(left == right);


### PR DESCRIPTION
Surfaces the existing LLVM-C value-replacement and instruction-removal interop on the hand-written OO layer, addressing the missing replace helpers noted in #148.

- `Value.ReplaceAllUsesWith(Value)` wraps `LLVMReplaceAllUsesWith`
- `Instruction.EraseFromParent` / `RemoveFromParent` wrap the matching `LLVMInstruction*` entry points
- `LLVMValueRef.InstructionRemoveFromParent` passthrough

`ReplaceAllUsesWith` is a direct 1:1 passthrough to LLVM's `Value::replaceAllUsesWith` -- there is no managed overhead, so the slowness reported in #148 is inherent to LLVM's O(#uses) use-list walk. The higher-level `ReplaceInstWith*` utilities live in `BasicBlockUtils.h`, which is not part of the LLVM-C API; the idiomatic equivalent is build-then-replace-then-erase, which these wrappers now make ergonomic (no alloca/store/load workaround needed).

Build is clean (0 warnings) and all 2587 tests pass.

Closes #148