### PR TITLE
Validate constant type preconditions in the LLVMValueRef Create* wrappers

### DIFF
--- a/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using static LLVMSharp.Interop.LLVMTailCallKind;
 
@@ -852,9 +853,13 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
                                             or LLVMTypeKind.LLVMFP128TypeKind
                                             or LLVMTypeKind.LLVMPPC_FP128TypeKind))
         {
-            throw new ArgumentException($"Expected a floating-point type, but was given '{RealTy.Kind}'. Use {nameof(CreateConstInt)} to create integer constants.", paramName);
+            ThrowNotFloatingPointType(RealTy, paramName);
         }
     }
+
+    [DoesNotReturn]
+    private static void ThrowNotFloatingPointType(LLVMTypeRef RealTy, string paramName) =>
+        throw new ArgumentException($"Expected a floating-point type, but was given '{RealTy.Kind}'. Use {nameof(CreateConstInt)} to create integer constants.", paramName);
 
     // libLLVM's ConstInt family maps onto ConstantInt::get via unwrap<IntegerType>, so it requires
     // an integer type; anything else silently produces corrupt IR (e.g. 'i0 0' for a double type)
@@ -864,27 +869,39 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
     {
         if (IntTy.Kind is not LLVMTypeKind.LLVMIntegerTypeKind)
         {
-            throw new ArgumentException($"Expected an integer type, but was given '{IntTy.Kind}'. Use {nameof(CreateConstReal)} to create floating-point constants.", paramName);
+            ThrowNotIntegerType(IntTy, paramName);
         }
     }
+
+    [DoesNotReturn]
+    private static void ThrowNotIntegerType(LLVMTypeRef IntTy, string paramName) =>
+        throw new ArgumentException($"Expected an integer type, but was given '{IntTy.Kind}'. Use {nameof(CreateConstReal)} to create floating-point constants.", paramName);
 
     // Mirrors LLVM's isIntOrIntVectorTy assert on ConstantExpr::getIntToPtr/getPtrToInt.
     private static void ThrowIfNotIntOrIntVectorType(LLVMTypeRef Ty, string paramName)
     {
         if (GetScalarType(Ty).Kind is not LLVMTypeKind.LLVMIntegerTypeKind)
         {
-            throw new ArgumentException($"Expected an integer or integer vector type, but was given '{Ty.Kind}'.", paramName);
+            ThrowNotIntOrIntVectorType(Ty, paramName);
         }
     }
+
+    [DoesNotReturn]
+    private static void ThrowNotIntOrIntVectorType(LLVMTypeRef Ty, string paramName) =>
+        throw new ArgumentException($"Expected an integer or integer vector type, but was given '{Ty.Kind}'.", paramName);
 
     // Mirrors LLVM's isPtrOrPtrVectorTy assert on ConstantExpr::getIntToPtr/getPtrToInt.
     private static void ThrowIfNotPtrOrPtrVectorType(LLVMTypeRef Ty, string paramName)
     {
         if (GetScalarType(Ty).Kind is not LLVMTypeKind.LLVMPointerTypeKind)
         {
-            throw new ArgumentException($"Expected a pointer or pointer vector type, but was given '{Ty.Kind}'.", paramName);
+            ThrowNotPtrOrPtrVectorType(Ty, paramName);
         }
     }
+
+    [DoesNotReturn]
+    private static void ThrowNotPtrOrPtrVectorType(LLVMTypeRef Ty, string paramName) =>
+        throw new ArgumentException($"Expected a pointer or pointer vector type, but was given '{Ty.Kind}'.", paramName);
 
     private static LLVMTypeRef GetScalarType(LLVMTypeRef Ty) => Ty.Kind is LLVMTypeKind.LLVMVectorTypeKind or LLVMTypeKind.LLVMScalableVectorTypeKind ? Ty.ElementType : Ty;
 

--- a/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
@@ -795,12 +795,17 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public static LLVMValueRef CreateConstPtrToInt(LLVMValueRef ConstantVal, LLVMTypeRef ToType) => LLVM.ConstPtrToInt(ConstantVal, ToType);
 
-    public static LLVMValueRef CreateConstReal(LLVMTypeRef RealTy, double N) => LLVM.ConstReal(RealTy, N);
+    public static LLVMValueRef CreateConstReal(LLVMTypeRef RealTy, double N)
+    {
+        ThrowIfNotFloatingPointType(RealTy, nameof(RealTy));
+        return LLVM.ConstReal(RealTy, N);
+    }
 
     public static LLVMValueRef CreateConstRealOfString(LLVMTypeRef RealTy, string Text) => CreateConstRealOfString(RealTy, Text.AsSpan());
 
     public static LLVMValueRef CreateConstRealOfString(LLVMTypeRef RealTy, ReadOnlySpan<char> Text)
     {
+        ThrowIfNotFloatingPointType(RealTy, nameof(RealTy));
         using var marshaledText = new MarshaledString(Text);
         return LLVM.ConstRealOfString(RealTy, marshaledText);
     }
@@ -809,8 +814,29 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public static LLVMValueRef CreateConstRealOfStringAndSize(LLVMTypeRef RealTy, ReadOnlySpan<char> Text)
     {
+        ThrowIfNotFloatingPointType(RealTy, nameof(RealTy));
         using var marshaledText = new MarshaledString(Text);
         return LLVM.ConstRealOfStringAndSize(RealTy, marshaledText, (uint)marshaledText.Length);
+    }
+
+    // libLLVM's ConstReal family maps onto ConstantFP::get, which requires a floating-point
+    // (or floating-point vector) type; anything else asserts in a checked build and is undefined
+    // behavior otherwise -- see dotnet/LLVMSharp#194. Catch it here so the safer wrapper surfaces
+    // a clear error instead of the raw binding corrupting IR or crashing.
+    private static void ThrowIfNotFloatingPointType(LLVMTypeRef RealTy, string paramName)
+    {
+        var scalarTy = RealTy.Kind is LLVMTypeKind.LLVMVectorTypeKind or LLVMTypeKind.LLVMScalableVectorTypeKind ? RealTy.ElementType : RealTy;
+
+        if (scalarTy.Kind is not (LLVMTypeKind.LLVMHalfTypeKind
+                               or LLVMTypeKind.LLVMBFloatTypeKind
+                               or LLVMTypeKind.LLVMFloatTypeKind
+                               or LLVMTypeKind.LLVMDoubleTypeKind
+                               or LLVMTypeKind.LLVMX86_FP80TypeKind
+                               or LLVMTypeKind.LLVMFP128TypeKind
+                               or LLVMTypeKind.LLVMPPC_FP128TypeKind))
+        {
+            throw new ArgumentException($"Expected a floating-point type, but was given '{RealTy.Kind}'. Use {nameof(CreateConstInt)} to create integer constants.", paramName);
+        }
     }
 
     public static LLVMValueRef CreateConstShuffleVector(LLVMValueRef VectorAConstant, LLVMValueRef VectorBConstant, LLVMValueRef MaskConstant) => LLVM.ConstShuffleVector(VectorAConstant, VectorBConstant, MaskConstant);

--- a/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
@@ -733,12 +733,17 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public static LLVMValueRef CreateConstInsertElement(LLVMValueRef VectorConstant, LLVMValueRef ElementValueConstant, LLVMValueRef IndexConstant) => LLVM.ConstInsertElement(VectorConstant, ElementValueConstant, IndexConstant);
 
-    public static LLVMValueRef CreateConstInt(LLVMTypeRef IntTy, ulong N, bool SignExtend = false) => LLVM.ConstInt(IntTy, N, SignExtend ? 1 : 0);
+    public static LLVMValueRef CreateConstInt(LLVMTypeRef IntTy, ulong N, bool SignExtend = false)
+    {
+        ThrowIfNotIntegerType(IntTy, nameof(IntTy));
+        return LLVM.ConstInt(IntTy, N, SignExtend ? 1 : 0);
+    }
 
     public static LLVMValueRef CreateConstIntOfArbitraryPrecision(LLVMTypeRef IntTy, ulong[] Words) => CreateConstIntOfArbitraryPrecision(IntTy, Words.AsSpan());
 
     public static LLVMValueRef CreateConstIntOfArbitraryPrecision(LLVMTypeRef IntTy, ReadOnlySpan<ulong> Words)
     {
+        ThrowIfNotIntegerType(IntTy, nameof(IntTy));
         fixed (ulong* pWords = Words)
         {
             return LLVM.ConstIntOfArbitraryPrecision(IntTy, (uint)Words.Length, pWords);
@@ -749,6 +754,7 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public static LLVMValueRef CreateConstIntOfString(LLVMTypeRef IntTy, ReadOnlySpan<char> Text, byte Radix)
     {
+        ThrowIfNotIntegerType(IntTy, nameof(IntTy));
         using var marshaledText = new MarshaledString(Text);
         return LLVM.ConstIntOfString(IntTy, marshaledText, Radix);
     }
@@ -757,6 +763,7 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public static LLVMValueRef CreateConstIntOfStringAndSize(LLVMTypeRef IntTy, ReadOnlySpan<char> Text, byte Radix)
     {
+        ThrowIfNotIntegerType(IntTy, nameof(IntTy));
         using var marshaledText = new MarshaledString(Text);
         return LLVM.ConstIntOfStringAndSize(IntTy, marshaledText, (uint)marshaledText.Length, Radix);
     }
@@ -836,6 +843,18 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
                                or LLVMTypeKind.LLVMPPC_FP128TypeKind))
         {
             throw new ArgumentException($"Expected a floating-point type, but was given '{RealTy.Kind}'. Use {nameof(CreateConstInt)} to create integer constants.", paramName);
+        }
+    }
+
+    // libLLVM's ConstInt family maps onto ConstantInt::get via unwrap<IntegerType>, so it requires
+    // an integer type; anything else silently produces corrupt IR (e.g. 'i0 0' for a double type)
+    // rather than erroring -- the integer-side analogue of dotnet/LLVMSharp#194. Unlike ConstReal,
+    // these don't accept vector types.
+    private static void ThrowIfNotIntegerType(LLVMTypeRef IntTy, string paramName)
+    {
+        if (IntTy.Kind is not LLVMTypeKind.LLVMIntegerTypeKind)
+        {
+            throw new ArgumentException($"Expected an integer type, but was given '{IntTy.Kind}'. Use {nameof(CreateConstReal)} to create floating-point constants.", paramName);
         }
     }
 

--- a/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
@@ -768,7 +768,13 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
         return LLVM.ConstIntOfStringAndSize(IntTy, marshaledText, (uint)marshaledText.Length, Radix);
     }
 
-    public static LLVMValueRef CreateConstIntToPtr(LLVMValueRef ConstantVal, LLVMTypeRef ToType) => LLVM.ConstIntToPtr(ConstantVal, ToType);
+    public static LLVMValueRef CreateConstIntToPtr(LLVMValueRef ConstantVal, LLVMTypeRef ToType)
+    {
+        // Mirrors ConstantExpr::getIntToPtr: integer source, pointer destination.
+        ThrowIfNotIntOrIntVectorType(ConstantVal.TypeOf, nameof(ConstantVal));
+        ThrowIfNotPtrOrPtrVectorType(ToType, nameof(ToType));
+        return LLVM.ConstIntToPtr(ConstantVal, ToType);
+    }
 
     public static LLVMValueRef CreateConstNamedStruct(LLVMTypeRef StructTy, LLVMValueRef[] ConstantVals) => CreateConstNamedStruct(StructTy, ConstantVals.AsSpan());
 
@@ -800,7 +806,13 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public static LLVMValueRef CreateConstPointerNull(LLVMTypeRef Ty) => LLVM.ConstPointerNull(Ty);
 
-    public static LLVMValueRef CreateConstPtrToInt(LLVMValueRef ConstantVal, LLVMTypeRef ToType) => LLVM.ConstPtrToInt(ConstantVal, ToType);
+    public static LLVMValueRef CreateConstPtrToInt(LLVMValueRef ConstantVal, LLVMTypeRef ToType)
+    {
+        // Mirrors ConstantExpr::getPtrToInt: pointer source, integer destination.
+        ThrowIfNotPtrOrPtrVectorType(ConstantVal.TypeOf, nameof(ConstantVal));
+        ThrowIfNotIntOrIntVectorType(ToType, nameof(ToType));
+        return LLVM.ConstPtrToInt(ConstantVal, ToType);
+    }
 
     public static LLVMValueRef CreateConstReal(LLVMTypeRef RealTy, double N)
     {
@@ -832,15 +844,13 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
     // a clear error instead of the raw binding corrupting IR or crashing.
     private static void ThrowIfNotFloatingPointType(LLVMTypeRef RealTy, string paramName)
     {
-        var scalarTy = RealTy.Kind is LLVMTypeKind.LLVMVectorTypeKind or LLVMTypeKind.LLVMScalableVectorTypeKind ? RealTy.ElementType : RealTy;
-
-        if (scalarTy.Kind is not (LLVMTypeKind.LLVMHalfTypeKind
-                               or LLVMTypeKind.LLVMBFloatTypeKind
-                               or LLVMTypeKind.LLVMFloatTypeKind
-                               or LLVMTypeKind.LLVMDoubleTypeKind
-                               or LLVMTypeKind.LLVMX86_FP80TypeKind
-                               or LLVMTypeKind.LLVMFP128TypeKind
-                               or LLVMTypeKind.LLVMPPC_FP128TypeKind))
+        if (GetScalarType(RealTy).Kind is not (LLVMTypeKind.LLVMHalfTypeKind
+                                            or LLVMTypeKind.LLVMBFloatTypeKind
+                                            or LLVMTypeKind.LLVMFloatTypeKind
+                                            or LLVMTypeKind.LLVMDoubleTypeKind
+                                            or LLVMTypeKind.LLVMX86_FP80TypeKind
+                                            or LLVMTypeKind.LLVMFP128TypeKind
+                                            or LLVMTypeKind.LLVMPPC_FP128TypeKind))
         {
             throw new ArgumentException($"Expected a floating-point type, but was given '{RealTy.Kind}'. Use {nameof(CreateConstInt)} to create integer constants.", paramName);
         }
@@ -857,6 +867,26 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
             throw new ArgumentException($"Expected an integer type, but was given '{IntTy.Kind}'. Use {nameof(CreateConstReal)} to create floating-point constants.", paramName);
         }
     }
+
+    // Mirrors LLVM's isIntOrIntVectorTy assert on ConstantExpr::getIntToPtr/getPtrToInt.
+    private static void ThrowIfNotIntOrIntVectorType(LLVMTypeRef Ty, string paramName)
+    {
+        if (GetScalarType(Ty).Kind is not LLVMTypeKind.LLVMIntegerTypeKind)
+        {
+            throw new ArgumentException($"Expected an integer or integer vector type, but was given '{Ty.Kind}'.", paramName);
+        }
+    }
+
+    // Mirrors LLVM's isPtrOrPtrVectorTy assert on ConstantExpr::getIntToPtr/getPtrToInt.
+    private static void ThrowIfNotPtrOrPtrVectorType(LLVMTypeRef Ty, string paramName)
+    {
+        if (GetScalarType(Ty).Kind is not LLVMTypeKind.LLVMPointerTypeKind)
+        {
+            throw new ArgumentException($"Expected a pointer or pointer vector type, but was given '{Ty.Kind}'.", paramName);
+        }
+    }
+
+    private static LLVMTypeRef GetScalarType(LLVMTypeRef Ty) => Ty.Kind is LLVMTypeKind.LLVMVectorTypeKind or LLVMTypeKind.LLVMScalableVectorTypeKind ? Ty.ElementType : Ty;
 
     public static LLVMValueRef CreateConstShuffleVector(LLVMValueRef VectorAConstant, LLVMValueRef VectorBConstant, LLVMValueRef MaskConstant) => LLVM.ConstShuffleVector(VectorAConstant, VectorBConstant, MaskConstant);
 

--- a/tests/LLVMSharp.UnitTests/Constants.cs
+++ b/tests/LLVMSharp.UnitTests/Constants.cs
@@ -39,4 +39,41 @@ public class Constants
         var value = LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, 8);
         Assert.That(value.Handle, Is.Not.EqualTo(IntPtr.Zero));
     }
+
+    [Test]
+    public void CreateConstIntToPtrRejectsNonIntegerSource()
+    {
+        // Mirrors ConstantExpr::getIntToPtr's "source must be integer" assert.
+        var ptrTy = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
+        var notAnInt = LLVMValueRef.CreateConstNull(ptrTy);
+        var ex = Assert.Throws<ArgumentException>(() => LLVMValueRef.CreateConstIntToPtr(notAnInt, ptrTy));
+        Assert.That(ex!.ParamName, Is.EqualTo("ConstantVal"));
+    }
+
+    [Test]
+    public void CreateConstIntToPtrRejectsNonPointerDestination()
+    {
+        // Mirrors ConstantExpr::getIntToPtr's "destination must be a pointer" assert.
+        var intVal = LLVMValueRef.CreateConstInt(LLVMTypeRef.Int64, 0);
+        var ex = Assert.Throws<ArgumentException>(() => LLVMValueRef.CreateConstIntToPtr(intVal, LLVMTypeRef.Int32));
+        Assert.That(ex!.ParamName, Is.EqualTo("ToType"));
+    }
+
+    [Test]
+    public void CreateConstPtrToIntRejectsNonPointerSource()
+    {
+        // Mirrors ConstantExpr::getPtrToInt's "source must be pointer" assert.
+        var intVal = LLVMValueRef.CreateConstInt(LLVMTypeRef.Int64, 0);
+        var ex = Assert.Throws<ArgumentException>(() => LLVMValueRef.CreateConstPtrToInt(intVal, LLVMTypeRef.Int32));
+        Assert.That(ex!.ParamName, Is.EqualTo("ConstantVal"));
+    }
+
+    [Test]
+    public void CreateConstPtrToIntAcceptsPointerSourceAndIntegerDestination()
+    {
+        var ptrTy = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
+        var ptrVal = LLVMValueRef.CreateConstNull(ptrTy);
+        var value = LLVMValueRef.CreateConstPtrToInt(ptrVal, LLVMTypeRef.Int64);
+        Assert.That(value.Handle, Is.Not.EqualTo(IntPtr.Zero));
+    }
 }

--- a/tests/LLVMSharp.UnitTests/Constants.cs
+++ b/tests/LLVMSharp.UnitTests/Constants.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using LLVMSharp.Interop;
+using NUnit.Framework;
+
+namespace LLVMSharp.UnitTests;
+
+public class Constants
+{
+    [Test]
+    public void CreateConstRealRejectsNonFloatingPointType()
+    {
+        // Regression for dotnet/LLVMSharp#194: ConstReal on an integer type is invalid usage
+        // that previously produced corrupt IR (ppc_fp128) or crashed the raw binding.
+        var ex = Assert.Throws<ArgumentException>(() => LLVMValueRef.CreateConstReal(LLVMTypeRef.Int32, 8));
+        Assert.That(ex!.ParamName, Is.EqualTo("RealTy"));
+    }
+
+    [Test]
+    public void CreateConstRealAcceptsFloatingPointType([Values] bool useVector)
+    {
+        var ty = useVector ? LLVMTypeRef.CreateVector(LLVMTypeRef.Double, 2) : LLVMTypeRef.Double;
+        var value = LLVMValueRef.CreateConstReal(ty, 8);
+        Assert.That(value.Handle, Is.Not.EqualTo(IntPtr.Zero));
+    }
+}

--- a/tests/LLVMSharp.UnitTests/Constants.cs
+++ b/tests/LLVMSharp.UnitTests/Constants.cs
@@ -24,4 +24,19 @@ public class Constants
         var value = LLVMValueRef.CreateConstReal(ty, 8);
         Assert.That(value.Handle, Is.Not.EqualTo(IntPtr.Zero));
     }
+
+    [Test]
+    public void CreateConstIntRejectsNonIntegerType()
+    {
+        // Integer-side analogue of #194: ConstInt on a non-integer type silently produced 'i0 0'.
+        var ex = Assert.Throws<ArgumentException>(() => LLVMValueRef.CreateConstInt(LLVMTypeRef.Double, 8));
+        Assert.That(ex!.ParamName, Is.EqualTo("IntTy"));
+    }
+
+    [Test]
+    public void CreateConstIntAcceptsIntegerType()
+    {
+        var value = LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, 8);
+        Assert.That(value.Handle, Is.Not.EqualTo(IntPtr.Zero));
+    }
 }


### PR DESCRIPTION
Fixes #194.

The `LLVMValueRef.Create*` helpers are billed as the "safer (but still lowlevel)" wrappers over the raw bindings, but several of the constant creators pass a mistyped operand straight through to libLLVM, where it either silently produces corrupt IR or -- on a release `libLLVM` with asserts compiled out -- access-violates. #194 is the canonical example: `CreateConstReal` on an `i32` reinterpreted the type as `ppc_fp128` on LLVM 14 and hard-crashes on current libLLVM. The module verifier can't cover this, since the raw binding faults before you can verify.

This mirrors libLLVM's own C++ asserts in the wrappers so the mistake surfaces as a clear `ArgumentException` pointing at the right helper, while the raw `LLVM.*` bindings stay unchecked by design.

----------

`CreateConstReal` / `CreateConstRealOfString` / `CreateConstRealOfStringAndSize` now require a floating-point (scalar or vector) type, matching `ConstantFP::get`.

----------

`CreateConstInt` / `CreateConstIntOfArbitraryPrecision` / `CreateConstIntOfString` / `CreateConstIntOfStringAndSize` now require an integer type, matching `ConstantInt::get` via `unwrap<IntegerType>`. Without this, `CreateConstInt(Double, 8)` silently returns `i0 0`.

----------

`CreateConstIntToPtr` / `CreateConstPtrToInt` now require the operand and target to be int-or-int-vector / ptr-or-ptr-vector on the correct sides, matching the asserts in `ConstantExpr::getIntToPtr` / `getPtrToInt`. Swapping the two is an easy footgun.

The checks are factored through a shared `GetScalarType` helper so scalar and vector types are handled the same way libLLVM does.

Intentionally left alone: `CreateConstBitCast` -- its contract is `CastInst::castIsValid`, which isn't a trivial type-kind check, so approximating it would be worse than deferring to the verifier -- and the `IRBuilder` `Build*` surface, which is deliberately lowlevel and covered by `Verify`/`TryVerify`.

Tests: added `tests/LLVMSharp.UnitTests/Constants.cs` covering each guard's reject and accept paths. Full suite is green (2596 passed, 0 warnings).
