### PR TITLE
Add managed accessors for types, values, constants, and globals

### DIFF
--- a/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
@@ -13,6 +13,19 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 {
     public IntPtr Handle = handle;
 
+    public readonly LLVMValueRef Aliasee
+    {
+        get
+        {
+            return (IsAGlobalAlias != null) ? LLVM.AliasGetAliasee(this) : default;
+        }
+
+        set
+        {
+            LLVM.AliasSetAliasee(this, value);
+        }
+    }
+
     public readonly uint Alignment
     {
         get
@@ -40,6 +53,10 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
     }
 
     public readonly uint BasicBlocksCount => (IsAFunction != null) ? LLVM.CountBasicBlocks(this) : default;
+
+    public readonly LLVMBasicBlockRef BlockAddressBasicBlock => (IsABlockAddress != null) ? LLVM.GetBlockAddressBasicBlock(this) : default;
+
+    public readonly LLVMValueRef BlockAddressFunction => (IsABlockAddress != null) ? LLVM.GetBlockAddressFunction(this) : default;
 
     public readonly LLVMValueRef Condition
     {
@@ -147,6 +164,19 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
         {
             using var marshaledName = new MarshaledString(value.AsSpan());
             LLVM.SetGC(this, marshaledName);
+        }
+    }
+
+    public readonly LLVMValueRef GlobalIFuncResolver
+    {
+        get
+        {
+            return (IsAGlobalIFunc != null) ? LLVM.GetGlobalIFuncResolver(this) : default;
+        }
+
+        set
+        {
+            LLVM.SetGlobalIFuncResolver(this, value);
         }
     }
 
@@ -635,6 +665,19 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
     }
 
     public readonly LLVMTypeRef TypeOf => (Handle != IntPtr.Zero) ? LLVM.TypeOf(this) : default;
+
+    public readonly LLVMUnnamedAddr UnnamedAddress
+    {
+        get
+        {
+            return (IsAGlobalValue != null) ? LLVM.GetUnnamedAddress(this) : default;
+        }
+
+        set
+        {
+            LLVM.SetUnnamedAddress(this, value);
+        }
+    }
 
     public readonly LLVMValueUsesEnumerable Uses => new LLVMValueUsesEnumerable(this);
 

--- a/sources/LLVMSharp/LLVMContext.cs
+++ b/sources/LLVMSharp/LLVMContext.cs
@@ -1,20 +1,31 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using LLVMSharp.Interop;
 
 namespace LLVMSharp;
 
 public sealed class LLVMContext : IEquatable<LLVMContext>
 {
+    private static readonly ConcurrentDictionary<LLVMContextRef, WeakReference<LLVMContext>> s_createdContexts = new ConcurrentDictionary<LLVMContextRef, WeakReference<LLVMContext>>();
+
+    private static readonly Lock s_createContextLock = new Lock();
+
     private readonly Dictionary<LLVMValueRef, WeakReference<Value>> _createdValues = [];
     private readonly Dictionary<LLVMTypeRef, WeakReference<Type>> _createdTypes = [];
 
-    public LLVMContext()
+    public LLVMContext() : this(LLVMContextRef.Create())
     {
-        Handle = LLVMContextRef.Create();
+    }
+
+    private LLVMContext(LLVMContextRef handle)
+    {
+        Handle = handle;
+        s_createdContexts.GetOrAdd(handle, static (_) => new WeakReference<LLVMContext>(null!)).SetTarget(this);
     }
 
     public LLVMContextRef Handle { get; }
@@ -38,6 +49,30 @@ public sealed class LLVMContext : IEquatable<LLVMContext>
     public override int GetHashCode() => Handle.GetHashCode();
 
     public override string ToString() => Handle.ToString();
+
+    internal static LLVMContext GetOrCreate(LLVMContextRef handle)
+    {
+        if (handle == null)
+        {
+            Debug.Assert(handle != null);
+            return null!;
+        }
+
+        var contextRef = s_createdContexts.GetOrAdd(handle, static (_) => new WeakReference<LLVMContext>(null!));
+
+        if (!contextRef.TryGetTarget(out var context))
+        {
+            lock (s_createContextLock)
+            {
+                if (!contextRef.TryGetTarget(out context))
+                {
+                    context = new LLVMContext(handle);
+                    contextRef.SetTarget(context);
+                }
+            }
+        }
+        return context;
+    }
 
     internal BasicBlock GetOrCreate(LLVMBasicBlockRef handle) => GetOrCreate<BasicBlock>(handle.AsValue());
 

--- a/sources/LLVMSharp/Types/ArrayType.cs
+++ b/sources/LLVMSharp/Types/ArrayType.cs
@@ -9,4 +9,6 @@ public sealed class ArrayType : SequentialType
     internal ArrayType(LLVMTypeRef handle) : base(handle, LLVMTypeKind.LLVMArrayTypeKind)
     {
     }
+
+    public ulong NumElements => Handle.ArrayLength2;
 }

--- a/sources/LLVMSharp/Types/FunctionType.cs
+++ b/sources/LLVMSharp/Types/FunctionType.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System;
 using LLVMSharp.Interop;
 
 namespace LLVMSharp;
@@ -8,5 +9,31 @@ public sealed class FunctionType : Type
 {
     internal FunctionType(LLVMTypeRef handle) : base(handle, LLVMTypeKind.LLVMFunctionTypeKind)
     {
+    }
+
+    public bool IsVarArg => Handle.IsFunctionVarArg;
+
+    public uint NumParams => Handle.ParamTypesCount;
+
+    public Type ReturnType => Context.GetOrCreate(Handle.ReturnType);
+
+    public Type[] GetParams()
+    {
+        var handles = Handle.GetParamTypes();
+
+        if (handles.Length == 0)
+        {
+            return [];
+        }
+
+        var context = Context;
+        var result = new Type[handles.Length];
+
+        for (var i = 0; i < result.Length; i++)
+        {
+            result[i] = context.GetOrCreate(handles[i]);
+        }
+
+        return result;
     }
 }

--- a/sources/LLVMSharp/Types/IntegerType.cs
+++ b/sources/LLVMSharp/Types/IntegerType.cs
@@ -9,4 +9,6 @@ public sealed class IntegerType : Type
     internal IntegerType(LLVMTypeRef handle) : base(handle, LLVMTypeKind.LLVMIntegerTypeKind)
     {
     }
+
+    public uint BitWidth => Handle.IntWidth;
 }

--- a/sources/LLVMSharp/Types/PointerType.cs
+++ b/sources/LLVMSharp/Types/PointerType.cs
@@ -9,4 +9,6 @@ public sealed class PointerType : Type
     internal PointerType(LLVMTypeRef handle) : base(handle, LLVMTypeKind.LLVMPointerTypeKind)
     {
     }
+
+    public uint AddressSpace => Handle.PointerAddressSpace;
 }

--- a/sources/LLVMSharp/Types/SequentialType.cs
+++ b/sources/LLVMSharp/Types/SequentialType.cs
@@ -9,4 +9,6 @@ public class SequentialType : CompositeType
     private protected SequentialType(LLVMTypeRef handle, LLVMTypeKind expectedTypeKind) : base(handle, expectedTypeKind)
     {
     }
+
+    public Type ElementType => Context.GetOrCreate(Handle.ElementType);
 }

--- a/sources/LLVMSharp/Types/StructType.cs
+++ b/sources/LLVMSharp/Types/StructType.cs
@@ -19,4 +19,54 @@ public sealed class StructType : CompositeType
         var handle = context.Handle.CreateNamedStruct(name);
         return context.GetOrCreate<StructType>(handle);
     }
+
+    public bool IsOpaque => Handle.IsOpaqueStruct;
+
+    public bool IsPacked => Handle.IsPackedStruct;
+
+    public string Name => Handle.StructName;
+
+    public uint NumElements => Handle.StructElementTypesCount;
+
+    public Type GetElementType(uint index) => Context.GetOrCreate(Handle.StructGetTypeAtIndex(index));
+
+    public Type[] GetElementTypes()
+    {
+        var handles = Handle.GetStructElementTypes();
+
+        if (handles.Length == 0)
+        {
+            return [];
+        }
+
+        var context = Context;
+        var result = new Type[handles.Length];
+
+        for (var i = 0; i < result.Length; i++)
+        {
+            result[i] = context.GetOrCreate(handles[i]);
+        }
+
+        return result;
+    }
+
+    public void SetBody(Type[] elementTypes, bool packed)
+    {
+        ArgumentNullException.ThrowIfNull(elementTypes);
+        SetBody(elementTypes.AsSpan(), packed);
+    }
+
+    public void SetBody(ReadOnlySpan<Type> elementTypes, bool packed)
+    {
+        var handles = new LLVMTypeRef[elementTypes.Length];
+
+        for (var i = 0; i < handles.Length; i++)
+        {
+            var elementType = elementTypes[i];
+            ArgumentNullException.ThrowIfNull(elementType);
+            handles[i] = elementType.Handle;
+        }
+
+        Handle.StructSetBody(handles, packed);
+    }
 }

--- a/sources/LLVMSharp/Types/Type.cs
+++ b/sources/LLVMSharp/Types/Type.cs
@@ -18,6 +18,54 @@ public class Type : IEquatable<Type>
 
     public LLVMTypeRef Handle { get; }
 
+    public LLVMContext Context => LLVMContext.GetOrCreate(Handle.Context);
+
+    public bool IsAggregateType => Handle.Kind is LLVMTypeKind.LLVMStructTypeKind or LLVMTypeKind.LLVMArrayTypeKind;
+
+    public bool IsArrayTy => Handle.Kind == LLVMTypeKind.LLVMArrayTypeKind;
+
+    public bool IsBFloatTy => Handle.Kind == LLVMTypeKind.LLVMBFloatTypeKind;
+
+    public bool IsDoubleTy => Handle.Kind == LLVMTypeKind.LLVMDoubleTypeKind;
+
+    public bool IsFP128Ty => Handle.Kind == LLVMTypeKind.LLVMFP128TypeKind;
+
+    public bool IsFloatTy => Handle.Kind == LLVMTypeKind.LLVMFloatTypeKind;
+
+    public bool IsFloatingPointTy => Handle.Kind is LLVMTypeKind.LLVMHalfTypeKind or LLVMTypeKind.LLVMBFloatTypeKind or LLVMTypeKind.LLVMFloatTypeKind or LLVMTypeKind.LLVMDoubleTypeKind or LLVMTypeKind.LLVMX86_FP80TypeKind or LLVMTypeKind.LLVMFP128TypeKind or LLVMTypeKind.LLVMPPC_FP128TypeKind;
+
+    public bool IsFunctionTy => Handle.Kind == LLVMTypeKind.LLVMFunctionTypeKind;
+
+    public bool IsHalfTy => Handle.Kind == LLVMTypeKind.LLVMHalfTypeKind;
+
+    public bool IsIntegerTy => Handle.Kind == LLVMTypeKind.LLVMIntegerTypeKind;
+
+    public bool IsLabelTy => Handle.Kind == LLVMTypeKind.LLVMLabelTypeKind;
+
+    public bool IsMetadataTy => Handle.Kind == LLVMTypeKind.LLVMMetadataTypeKind;
+
+    public bool IsPPCFP128Ty => Handle.Kind == LLVMTypeKind.LLVMPPC_FP128TypeKind;
+
+    public bool IsPointerTy => Handle.Kind == LLVMTypeKind.LLVMPointerTypeKind;
+
+    public bool IsSized => Handle.IsSized;
+
+    public bool IsStructTy => Handle.Kind == LLVMTypeKind.LLVMStructTypeKind;
+
+    public bool IsTokenTy => Handle.Kind == LLVMTypeKind.LLVMTokenTypeKind;
+
+    public bool IsVectorTy => Handle.Kind is LLVMTypeKind.LLVMVectorTypeKind or LLVMTypeKind.LLVMScalableVectorTypeKind;
+
+    public bool IsVoidTy => Handle.Kind == LLVMTypeKind.LLVMVoidTypeKind;
+
+    public bool IsX86AMXTy => Handle.Kind == LLVMTypeKind.LLVMX86_AMXTypeKind;
+
+    public bool IsX86FP80Ty => Handle.Kind == LLVMTypeKind.LLVMX86_FP80TypeKind;
+
+    public LLVMTypeKind Kind => Handle.Kind;
+
+    public Type ScalarType => (Handle.Kind is LLVMTypeKind.LLVMVectorTypeKind or LLVMTypeKind.LLVMScalableVectorTypeKind) ? Context.GetOrCreate(Handle.ElementType) : this;
+
     public static bool operator ==(Type? left, Type? right) => ReferenceEquals(left, right) || (left?.Handle == right?.Handle);
 
     public static bool operator !=(Type? left, Type? right) => !(left == right);
@@ -127,6 +175,10 @@ public class Type : IEquatable<Type>
     public override int GetHashCode() => Handle.GetHashCode();
 
     public override string ToString() => Handle.ToString();
+
+    public void Dump() => Handle.Dump();
+
+    public string PrintToString() => Handle.PrintToString();
 
     internal static Type Create(LLVMTypeRef handle) => handle.Kind switch
     {

--- a/sources/LLVMSharp/Types/VectorType.cs
+++ b/sources/LLVMSharp/Types/VectorType.cs
@@ -9,4 +9,6 @@ public sealed class VectorType : SequentialType
     internal VectorType(LLVMTypeRef handle) : base(handle, LLVMTypeKind.LLVMVectorTypeKind)
     {
     }
+
+    public uint NumElements => Handle.VectorSize;
 }

--- a/sources/LLVMSharp/Values/Users/Constants/BlockAddress.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/BlockAddress.cs
@@ -9,4 +9,8 @@ public sealed class BlockAddress : Constant
     internal BlockAddress(LLVMValueRef handle) : base(handle.IsABlockAddress, LLVMValueKind.LLVMBlockAddressValueKind)
     {
     }
+
+    public BasicBlock BasicBlock => Context.GetOrCreate(Handle.BlockAddressBasicBlock);
+
+    public Function Function => Context.GetOrCreate<Function>(Handle.BlockAddressFunction);
 }

--- a/sources/LLVMSharp/Values/Users/Constants/Constant.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/Constant.cs
@@ -10,6 +10,14 @@ public class Constant : User
     {
     }
 
+    public bool IsNullValue => Handle.IsNull;
+
+    public Constant? GetAggregateElement(uint index)
+    {
+        var handle = Handle.GetAggregateElement(index);
+        return (handle == null) ? null : Context.GetOrCreate<Constant>(handle);
+    }
+
     internal static new Constant Create(LLVMValueRef handle) => handle switch
     {
         _ when handle.IsABlockAddress != null => new BlockAddress(handle),

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantDataSequential.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantDataSequential.cs
@@ -10,6 +10,10 @@ public class ConstantDataSequential : ConstantData
     {
     }
 
+    public bool IsString => Handle.IsConstantString;
+
+    public string AsString() => Handle.GetAsString(out _);
+
     internal static new ConstantDataSequential Create(LLVMValueRef handle) => handle switch
     {
         _ when handle.IsAConstantDataArray != null => new ConstantDataArray(handle),

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantFP.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantFP.cs
@@ -9,4 +9,8 @@ public sealed class ConstantFP : ConstantData
     internal ConstantFP(LLVMValueRef handle) : base(handle.IsAConstantFP, LLVMValueKind.LLVMConstantFPValueKind)
     {
     }
+
+    public double ValueAsDouble => Handle.ConstRealDouble;
+
+    public double GetDouble(out bool losesInfo) => Handle.GetConstRealDouble(out losesInfo);
 }

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantInt.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantDatas/ConstantInt.cs
@@ -9,4 +9,8 @@ public sealed class ConstantInt : ConstantData
     internal ConstantInt(LLVMValueRef handle) : base(handle.IsAConstantInt, LLVMValueKind.LLVMConstantIntValueKind)
     {
     }
+
+    public long SExtValue => Handle.ConstIntSExt;
+
+    public ulong ZExtValue => Handle.ConstIntZExt;
 }

--- a/sources/LLVMSharp/Values/Users/Constants/ConstantExprs/ConstantExpr.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/ConstantExprs/ConstantExpr.cs
@@ -10,6 +10,8 @@ public class ConstantExpr : Constant
     {
     }
 
+    public LLVMOpcode Opcode => Handle.ConstOpcode;
+
     internal static new ConstantExpr Create(LLVMValueRef handle) => handle switch
     {
         _ => new ConstantExpr(handle),

--- a/sources/LLVMSharp/Values/Users/Constants/GlobalValues/Function.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/GlobalValues/Function.cs
@@ -31,6 +31,93 @@ public sealed class Function : GlobalObject
         Handle.AddAttributeAtIndex(index, attribute.Handle);
     }
 
+    public uint BasicBlocksCount => Handle.BasicBlocksCount;
+
+    public BasicBlock EntryBasicBlock => Context.GetOrCreate(Handle.EntryBasicBlock);
+
+    public FunctionType FunctionType => Context.GetOrCreate<FunctionType>(Handle.GlobalValueType);
+
+    public string GC
+    {
+        get
+        {
+            return Handle.GC;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.GC = value;
+        }
+    }
+
+    public uint IntrinsicID => Handle.IntrinsicID;
+
+    public uint NumParams => Handle.ParamsCount;
+
+    public Constant? PersonalityFn
+    {
+        get
+        {
+            var personalityFn = Handle.PersonalityFn;
+            return (personalityFn == null) ? null : Context.GetOrCreate<Constant>(personalityFn);
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.PersonalityFn = (value is not null) ? value.Handle : default;
+        }
+    }
+
+    public Type ReturnType => FunctionType.ReturnType;
+
+    public BasicBlock AppendBasicBlock(ReadOnlySpan<char> name) => Context.GetOrCreate(Handle.AppendBasicBlock(name));
+
+    public void EraseFromParent() => Handle.DeleteFunction();
+
+    public BasicBlock[] GetBasicBlocks()
+    {
+        var handles = Handle.GetBasicBlocks();
+
+        if (handles.Length == 0)
+        {
+            return [];
+        }
+
+        var context = Context;
+        var result = new BasicBlock[handles.Length];
+
+        for (var i = 0; i < result.Length; i++)
+        {
+            result[i] = context.GetOrCreate(handles[i]);
+        }
+
+        return result;
+    }
+
+    public Argument GetParam(uint index) => Context.GetOrCreate<Argument>(Handle.GetParam(index));
+
+    public Argument[] GetParams()
+    {
+        var handles = Handle.GetParams();
+
+        if (handles.Length == 0)
+        {
+            return [];
+        }
+
+        var context = Context;
+        var result = new Argument[handles.Length];
+
+        for (var i = 0; i < result.Length; i++)
+        {
+            result[i] = context.GetOrCreate<Argument>(handles[i]);
+        }
+
+        return result;
+    }
+
     public Attribute[] GetAttributesAtIndex(LLVMAttributeIndex index)
     {
         var handles = Handle.GetAttributesAtIndex(index);
@@ -45,4 +132,6 @@ public sealed class Function : GlobalObject
     }
 
     public void RemoveEnumAttributeAtIndex(LLVMAttributeIndex index, uint kindId) => Handle.RemoveEnumAttributeAtIndex(index, kindId);
+
+    public bool Verify(LLVMVerifierFailureAction action) => Handle.VerifyFunction(action);
 }

--- a/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalAlias.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalAlias.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System;
 using LLVMSharp.Interop;
 
 namespace LLVMSharp;
@@ -8,5 +9,21 @@ public sealed class GlobalAlias : GlobalIndirectSymbol
 {
     internal GlobalAlias(LLVMValueRef handle) : base(handle.IsAGlobalAlias, LLVMValueKind.LLVMGlobalAliasValueKind)
     {
+    }
+
+    public Constant? Aliasee
+    {
+        get
+        {
+            var aliasee = Handle.Aliasee;
+            return (aliasee == null) ? null : Context.GetOrCreate<Constant>(aliasee);
+        }
+
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            var handle = Handle;
+            handle.Aliasee = value.Handle;
+        }
     }
 }

--- a/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalIFunc.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalIFunc.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System;
 using LLVMSharp.Interop;
 
 namespace LLVMSharp;
@@ -8,5 +9,21 @@ public sealed class GlobalIFunc : GlobalIndirectSymbol
 {
     internal GlobalIFunc(LLVMValueRef handle) : base(handle.IsAGlobalIFunc, LLVMValueKind.LLVMGlobalIFuncValueKind)
     {
+    }
+
+    public Constant? Resolver
+    {
+        get
+        {
+            var resolver = Handle.GlobalIFuncResolver;
+            return (resolver == null) ? null : Context.GetOrCreate<Constant>(resolver);
+        }
+
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            var handle = Handle;
+            handle.GlobalIFuncResolver = value.Handle;
+        }
     }
 }

--- a/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalObject.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalObject.cs
@@ -10,6 +10,20 @@ public class GlobalObject : GlobalValue
     {
     }
 
+    public string Section
+    {
+        get
+        {
+            return Handle.Section;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.Section = value;
+        }
+    }
+
     internal static new GlobalObject Create(LLVMValueRef handle) => handle switch
     {
         _ when handle.IsAFunction != null => new Function(handle),

--- a/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalValue.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalValue.cs
@@ -23,6 +23,66 @@ public class GlobalValue : Constant
         }
     }
 
+    public LLVMDLLStorageClass DLLStorageClass
+    {
+        get
+        {
+            return Handle.DLLStorageClass;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.DLLStorageClass = value;
+        }
+    }
+
+    public bool IsDeclaration => Handle.IsDeclaration;
+
+    public LLVMLinkage Linkage
+    {
+        get
+        {
+            return Handle.Linkage;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.Linkage = value;
+        }
+    }
+
+    public LLVMUnnamedAddr UnnamedAddress
+    {
+        get
+        {
+            return Handle.UnnamedAddress;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.UnnamedAddress = value;
+        }
+    }
+
+    public Type ValueType => Context.GetOrCreate(Handle.GlobalValueType);
+
+    public LLVMVisibility Visibility
+    {
+        get
+        {
+            return Handle.Visibility;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.Visibility = value;
+        }
+    }
+
     internal static new GlobalValue Create(LLVMValueRef handle) => handle switch
     {
         _ when handle.IsAGlobalAlias != null => new GlobalAlias(handle),

--- a/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalVariable.cs
+++ b/sources/LLVMSharp/Values/Users/Constants/GlobalValues/GlobalVariable.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System;
 using LLVMSharp.Interop;
 
 namespace LLVMSharp;
@@ -9,4 +10,77 @@ public sealed class GlobalVariable : GlobalObject
     internal GlobalVariable(LLVMValueRef handle) : base(handle.IsAGlobalVariable, LLVMValueKind.LLVMGlobalVariableValueKind)
     {
     }
+
+    public Constant? Initializer
+    {
+        get
+        {
+            var initializer = Handle.Initializer;
+            return (initializer == null) ? null : Context.GetOrCreate<Constant>(initializer);
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.Initializer = (value is not null) ? value.Handle : default;
+        }
+    }
+
+    public bool IsConstant
+    {
+        get
+        {
+            return Handle.IsGlobalConstant;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.IsGlobalConstant = value;
+        }
+    }
+
+    public bool IsExternallyInitialized
+    {
+        get
+        {
+            return Handle.IsExternallyInitialized;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.IsExternallyInitialized = value;
+        }
+    }
+
+    public bool IsThreadLocal
+    {
+        get
+        {
+            return Handle.IsThreadLocal;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.IsThreadLocal = value;
+        }
+    }
+
+    public LLVMThreadLocalMode ThreadLocalMode
+    {
+        get
+        {
+            return Handle.ThreadLocalMode;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.ThreadLocalMode = value;
+        }
+    }
+
+    public void EraseFromParent() => Handle.DeleteGlobal();
 }

--- a/sources/LLVMSharp/Values/Users/User.cs
+++ b/sources/LLVMSharp/Values/Users/User.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System;
 using LLVMSharp.Interop;
 
 namespace LLVMSharp;
@@ -8,6 +9,16 @@ public class User : Value
 {
     private protected User(LLVMValueRef handle, LLVMValueKind expectedValueKind) : base(handle.IsAUser, expectedValueKind)
     {
+    }
+
+    public uint NumOperands => (uint)Handle.OperandCount;
+
+    public Value GetOperand(uint index) => Context.GetOrCreate(Handle.GetOperand(index));
+
+    public void SetOperand(uint index, Value value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        Handle.SetOperand(index, value.Handle);
     }
 
     internal static new User Create(LLVMValueRef handle) => handle switch

--- a/sources/LLVMSharp/Values/Value.cs
+++ b/sources/LLVMSharp/Values/Value.cs
@@ -18,6 +18,30 @@ public class Value : IEquatable<Value>
 
     public LLVMValueRef Handle { get; }
 
+    public LLVMContext Context => LLVMContext.GetOrCreate(Handle.Context);
+
+    public LLVMValueKind Kind => Handle.Kind;
+
+    public string Name
+    {
+        get
+        {
+            return Handle.Name;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.Name = value;
+        }
+    }
+
+    public Type Type => Context.GetOrCreate(Handle.TypeOf);
+
+    public void Dump() => Handle.Dump();
+
+    public string PrintToString() => Handle.PrintToString();
+
     public void ReplaceAllUsesWith(Value newValue)
     {
         ArgumentNullException.ThrowIfNull(newValue);

--- a/tests/LLVMSharp.UnitTests/ManagedApi.cs
+++ b/tests/LLVMSharp.UnitTests/ManagedApi.cs
@@ -1,0 +1,204 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using LLVMSharp.Interop;
+using NUnit.Framework;
+
+namespace LLVMSharp.UnitTests;
+
+public class ManagedApi
+{
+    [Test]
+    public void TypePredicates()
+    {
+        var context = new LLVMContext();
+
+        var int32 = Type.GetInt32Ty(context);
+        Assert.That(int32, Is.InstanceOf<IntegerType>());
+        Assert.That(int32.IsIntegerTy, Is.True);
+        Assert.That(int32.IsSized, Is.True);
+        Assert.That(int32.IsFloatingPointTy, Is.False);
+        Assert.That(int32.Kind, Is.EqualTo(LLVMTypeKind.LLVMIntegerTypeKind));
+        Assert.That(int32.ScalarType, Is.SameAs(int32));
+        Assert.That(int32.Context, Is.EqualTo(context));
+        Assert.That(((IntegerType)int32).BitWidth, Is.EqualTo(32u));
+
+        var flt = Type.GetFloatTy(context);
+        Assert.That(flt.IsFloatingPointTy, Is.True);
+        Assert.That(flt.IsFloatTy, Is.True);
+        Assert.That(flt.IsIntegerTy, Is.False);
+    }
+
+    [Test]
+    public void SequentialAndPointerTypes()
+    {
+        var context = new LLVMContext();
+        var int32 = Type.GetInt32Ty(context);
+
+        var vector = (VectorType)context.GetOrCreate(LLVMTypeRef.CreateVector(int32.Handle, 4));
+        Assert.That(vector.IsVectorTy, Is.True);
+        Assert.That(vector.NumElements, Is.EqualTo(4u));
+        Assert.That(vector.ElementType, Is.EqualTo(int32));
+        Assert.That(vector.ScalarType, Is.EqualTo(int32));
+
+        var array = (ArrayType)context.GetOrCreate(LLVMTypeRef.CreateArray(int32.Handle, 8));
+        Assert.That(array.IsArrayTy, Is.True);
+        Assert.That(array.NumElements, Is.EqualTo(8ul));
+        Assert.That(array.ElementType, Is.EqualTo(int32));
+
+        var pointer = (PointerType)context.GetOrCreate(LLVMTypeRef.CreatePointer(int32.Handle, 1));
+        Assert.That(pointer.IsPointerTy, Is.True);
+        Assert.That(pointer.AddressSpace, Is.EqualTo(1u));
+    }
+
+    [Test]
+    public void FunctionTypeAccessors()
+    {
+        var context = new LLVMContext();
+        var int32 = Type.GetInt32Ty(context);
+        var flt = Type.GetFloatTy(context);
+
+        var handle = LLVMTypeRef.CreateFunction(int32.Handle, [int32.Handle, flt.Handle], IsVarArg: false);
+        var functionType = (FunctionType)context.GetOrCreate(handle);
+
+        Assert.That(functionType.IsFunctionTy, Is.True);
+        Assert.That(functionType.ReturnType, Is.EqualTo(int32));
+        Assert.That(functionType.NumParams, Is.EqualTo(2u));
+        Assert.That(functionType.IsVarArg, Is.False);
+
+        var parameters = functionType.GetParams();
+        Assert.That(parameters.Length, Is.EqualTo(2));
+        Assert.That(parameters[0], Is.EqualTo(int32));
+        Assert.That(parameters[1], Is.EqualTo(flt));
+    }
+
+    [Test]
+    public void StructTypeAccessors()
+    {
+        var context = new LLVMContext();
+        var int32 = Type.GetInt32Ty(context);
+        var flt = Type.GetFloatTy(context);
+
+        var structType = StructType.Create(context, "MyStruct");
+        Assert.That(structType.Name, Is.EqualTo("MyStruct"));
+        Assert.That(structType.IsOpaque, Is.True);
+
+        structType.SetBody([int32, flt], packed: true);
+        Assert.That(structType.IsOpaque, Is.False);
+        Assert.That(structType.IsPacked, Is.True);
+        Assert.That(structType.NumElements, Is.EqualTo(2u));
+        Assert.That(structType.GetElementType(0), Is.EqualTo(int32));
+        Assert.That(structType.GetElementType(1), Is.EqualTo(flt));
+
+        var elementTypes = structType.GetElementTypes();
+        Assert.That(elementTypes.Length, Is.EqualTo(2));
+        Assert.That(elementTypes[0], Is.EqualTo(int32));
+    }
+
+    [Test]
+    public void ConstantIntAccessors()
+    {
+        var context = new LLVMContext();
+        var int32 = Type.GetInt32Ty(context);
+
+        // i32 with bit pattern 0xFFFFFFFB: zero-extends to 4294967291, sign-extends to -5.
+        var constant = (ConstantInt)context.GetOrCreate(LLVMValueRef.CreateConstInt(int32.Handle, 4294967291UL));
+        Assert.That(constant.ZExtValue, Is.EqualTo(4294967291UL));
+        Assert.That(constant.SExtValue, Is.EqualTo(-5L));
+        Assert.That(constant.Type, Is.EqualTo(int32));
+        Assert.That(constant.Kind, Is.EqualTo(LLVMValueKind.LLVMConstantIntValueKind));
+    }
+
+    [Test]
+    public void ConstantFPAccessors()
+    {
+        var context = new LLVMContext();
+        var doubleTy = Type.GetDoubleTy(context);
+
+        var constant = (ConstantFP)context.GetOrCreate(LLVMValueRef.CreateConstReal(doubleTy.Handle, 1.5));
+        Assert.That(constant.ValueAsDouble, Is.EqualTo(1.5));
+
+        var value = constant.GetDouble(out var losesInfo);
+        Assert.That(value, Is.EqualTo(1.5));
+        Assert.That(losesInfo, Is.False);
+    }
+
+    [Test]
+    public void ConstantAggregateAndNull()
+    {
+        var context = new LLVMContext();
+        var int32 = Type.GetInt32Ty(context);
+
+        var nullValue = (Constant)context.GetOrCreate(LLVMValueRef.CreateConstNull(int32.Handle));
+        Assert.That(nullValue.IsNullValue, Is.True);
+
+        var elements = new[]
+        {
+            LLVMValueRef.CreateConstInt(int32.Handle, 10),
+            LLVMValueRef.CreateConstInt(int32.Handle, 20),
+        };
+
+        var array = (Constant)context.GetOrCreate(LLVMValueRef.CreateConstArray(int32.Handle, elements));
+        var element0 = array.GetAggregateElement(0);
+        var element1 = array.GetAggregateElement(1);
+
+        Assert.That(element0, Is.InstanceOf<ConstantInt>());
+        Assert.That(((ConstantInt)element0!).ZExtValue, Is.EqualTo(10UL));
+        Assert.That(((ConstantInt)element1!).ZExtValue, Is.EqualTo(20UL));
+    }
+
+    [Test]
+    public void GlobalVariableAndUserOperands()
+    {
+        var context = new LLVMContext();
+        var module = context.Handle.CreateModuleWithName("m");
+        var int32 = Type.GetInt32Ty(context);
+
+        var global = (GlobalVariable)context.GetOrCreate(module.AddGlobal(int32.Handle, "g"));
+        Assert.That(global.ValueType, Is.EqualTo(int32));
+
+        global.Initializer = (Constant)context.GetOrCreate(LLVMValueRef.CreateConstInt(int32.Handle, 42));
+        global.IsConstant = true;
+        global.Linkage = LLVMLinkage.LLVMInternalLinkage;
+        global.Section = ".mysection";
+
+        Assert.That(global.IsConstant, Is.True);
+        Assert.That(global.Linkage, Is.EqualTo(LLVMLinkage.LLVMInternalLinkage));
+        Assert.That(global.Section, Is.EqualTo(".mysection"));
+
+        Assert.That(global.NumOperands, Is.EqualTo(1u));
+        Assert.That(((ConstantInt)global.GetOperand(0)).ZExtValue, Is.EqualTo(42UL));
+        Assert.That(global.Initializer, Is.Not.Null);
+        Assert.That(((ConstantInt)global.Initializer!).ZExtValue, Is.EqualTo(42UL));
+    }
+
+    [Test]
+    public void FunctionAccessors()
+    {
+        var context = new LLVMContext();
+        var module = context.Handle.CreateModuleWithName("m");
+        var int32 = Type.GetInt32Ty(context);
+
+        var functionType = LLVMTypeRef.CreateFunction(int32.Handle, [int32.Handle, int32.Handle], IsVarArg: false);
+        var function = (Function)context.GetOrCreate(module.AddFunction("f", functionType));
+
+        Assert.That(function.IsDeclaration, Is.True);
+        Assert.That(function.NumParams, Is.EqualTo(2u));
+        Assert.That(function.ReturnType, Is.EqualTo(int32));
+        Assert.That(function.FunctionType.NumParams, Is.EqualTo(2u));
+        Assert.That(function.IntrinsicID, Is.EqualTo(0u));
+
+        var parameter = function.GetParam(0);
+        Assert.That(parameter, Is.InstanceOf<Argument>());
+        Assert.That(parameter.Type, Is.EqualTo(int32));
+        Assert.That(function.GetParams().Length, Is.EqualTo(2));
+
+        function.CallingConvention = LLVMCallConv.LLVMColdCallConv;
+        Assert.That(function.CallingConvention, Is.EqualTo(LLVMCallConv.LLVMColdCallConv));
+
+        var entry = function.AppendBasicBlock("entry");
+        Assert.That(function.BasicBlocksCount, Is.EqualTo(1u));
+        Assert.That(function.EntryBasicBlock, Is.EqualTo(entry));
+        Assert.That(function.IsDeclaration, Is.False);
+        Assert.That(function.GetBasicBlocks().Length, Is.EqualTo(1));
+    }
+}


### PR DESCRIPTION
Fills in the high-level C++-mirroring managed API (`sources/LLVMSharp`) with the self-contained accessors that need no `libLLVMSharp` native support. This is the first of three slices: the instruction, module, and context/target surface follows in later PRs, and the native-dependent accessors come after the `libLLVMSharp` helpers land.

To let wrapper-returning accessors reach their owning context without threading it through every constructor, this mirrors ClangSharp's ownership model: `LLVMContext` keeps a static weak registry keyed by `LLVMContextRef`, and `Value`/`Type` recover their managed context from their own handle (`Handle.Context`).

----------

Added managed surface:
- **Types** — `Type` predicates, `Context`, `ScalarType`, `Dump`/`PrintToString`; `IntegerType.BitWidth`; `SequentialType.ElementType`; `ArrayType`/`VectorType.NumElements`; `PointerType.AddressSpace`; `FunctionType` return/params/vararg; `StructType` name/packed/opaque/elements/`SetBody`.
- **Value/User** — `Context`, `Kind`, `Name`, `Type`, `Dump`, `PrintToString`; `NumOperands`, `GetOperand`, `SetOperand`.
- **Constants** — `IsNullValue`, `GetAggregateElement`; `ConstantInt` `SExt`/`ZExtValue`; `ConstantFP` `ValueAsDouble`/`GetDouble`; `ConstantDataSequential` `IsString`/`AsString`; `ConstantExpr.Opcode`; `BlockAddress.Function`/`BasicBlock`.
- **Globals/Function** — `GlobalValue` linkage/visibility/DLL-storage/unnamed-addr/section/value-type; `GlobalVariable` initializer/constant/thread-local/erase; `Function` type/return/params/basic-blocks/GC/personality/verify; `GlobalAlias.Aliasee`; `GlobalIFunc.Resolver`.

----------

Also surfaces the existing `LLVMAliasGetAliasee`/`SetAliasee`, `LLVMGet`/`SetGlobalIFuncResolver`, `LLVMGet`/`SetUnnamedAddress`, and `LLVMGetBlockAddressFunction`/`BasicBlock` C-API on `LLVMValueRef`, which the managed accessors consume.

`Function.ReturnType` deliberately routes through `FunctionType.ReturnType` (pure LLVM-C) rather than the native `Function_getReturnType` helper, keeping it in this no-native slice.

Builds with 0 warnings; adds `ManagedApi.cs` (9 tests) exercising the new surface. `net10.0`, 2606 tests pass.
