### PR TITLE
Expand the managed API for Module, BasicBlock, Target, and instruction flags

### DIFF
--- a/sources/LLVMSharp.Interop/Extensions/LLVMModuleRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMModuleRef.cs
@@ -73,6 +73,33 @@ public unsafe partial struct LLVMModuleRef(IntPtr handle) : IDisposable, IEquata
         }
     }
 
+    public readonly string InlineAsm
+    {
+        get
+        {
+            if (Handle == IntPtr.Zero)
+            {
+                return string.Empty;
+            }
+
+            nuint len;
+            var pInlineAsm = LLVM.GetModuleInlineAsm(this, &len);
+
+            if (pInlineAsm == null)
+            {
+                return string.Empty;
+            }
+
+            return SpanExtensions.AsString(pInlineAsm);
+        }
+
+        set
+        {
+            using var marshaledInlineAsm = new MarshaledString(value.AsSpan());
+            LLVM.SetModuleInlineAsm2(this, marshaledInlineAsm, (nuint)marshaledInlineAsm.Length);
+        }
+    }
+
     public readonly LLVMValueRef LastFunction => (Handle != IntPtr.Zero) ? LLVM.GetLastFunction(this) : default;
 
     public readonly LLVMValueRef LastGlobal => (Handle != IntPtr.Zero) ? LLVM.GetLastGlobal(this) : default;
@@ -84,6 +111,60 @@ public unsafe partial struct LLVMModuleRef(IntPtr handle) : IDisposable, IEquata
     public readonly LLVMNamedMDNodeRef LastNamedMetadata => (Handle != IntPtr.Zero) ? LLVM.GetLastNamedMetadata(this) : default;
 
     public readonly LLVMModuleNamedMetadataEnumerable NamedMetadata => new LLVMModuleNamedMetadataEnumerable(this);
+
+    public readonly string ModuleIdentifier
+    {
+        get
+        {
+            if (Handle == IntPtr.Zero)
+            {
+                return string.Empty;
+            }
+
+            nuint len;
+            var pModuleIdentifier = LLVM.GetModuleIdentifier(this, &len);
+
+            if (pModuleIdentifier == null)
+            {
+                return string.Empty;
+            }
+
+            return SpanExtensions.AsString(pModuleIdentifier);
+        }
+
+        set
+        {
+            using var marshaledModuleIdentifier = new MarshaledString(value.AsSpan());
+            LLVM.SetModuleIdentifier(this, marshaledModuleIdentifier, (nuint)marshaledModuleIdentifier.Length);
+        }
+    }
+
+    public readonly string SourceFileName
+    {
+        get
+        {
+            if (Handle == IntPtr.Zero)
+            {
+                return string.Empty;
+            }
+
+            nuint len;
+            var pSourceFileName = LLVM.GetSourceFileName(this, &len);
+
+            if (pSourceFileName == null)
+            {
+                return string.Empty;
+            }
+
+            return SpanExtensions.AsString(pSourceFileName);
+        }
+
+        set
+        {
+            using var marshaledSourceFileName = new MarshaledString(value.AsSpan());
+            LLVM.SetSourceFileName(this, marshaledSourceFileName, (nuint)marshaledSourceFileName.Length);
+        }
+    }
 
     public readonly string Target
     {

--- a/sources/LLVMSharp.Interop/Extensions/LLVMTargetMachineRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMTargetMachineRef.cs
@@ -17,6 +17,59 @@ public unsafe partial struct LLVMTargetMachineRef(IntPtr handle) : IEquatable<LL
 
     public static bool operator !=(LLVMTargetMachineRef left, LLVMTargetMachineRef right) => !(left == right);
 
+    public readonly string CPU
+    {
+        get
+        {
+            var pCPU = LLVM.GetTargetMachineCPU(this);
+
+            if (pCPU == null)
+            {
+                return string.Empty;
+            }
+
+            var result = SpanExtensions.AsString(pCPU);
+            LLVM.DisposeMessage(pCPU);
+            return result;
+        }
+    }
+
+    public readonly string FeatureString
+    {
+        get
+        {
+            var pFeatureString = LLVM.GetTargetMachineFeatureString(this);
+
+            if (pFeatureString == null)
+            {
+                return string.Empty;
+            }
+
+            var result = SpanExtensions.AsString(pFeatureString);
+            LLVM.DisposeMessage(pFeatureString);
+            return result;
+        }
+    }
+
+    public readonly LLVMTargetRef Target => (Handle != IntPtr.Zero) ? LLVM.GetTargetMachineTarget(this) : default;
+
+    public readonly string Triple
+    {
+        get
+        {
+            var pTriple = LLVM.GetTargetMachineTriple(this);
+
+            if (pTriple == null)
+            {
+                return string.Empty;
+            }
+
+            var result = SpanExtensions.AsString(pTriple);
+            LLVM.DisposeMessage(pTriple);
+            return result;
+        }
+    }
+
     public readonly LLVMTargetDataRef CreateTargetDataLayout() => LLVM.CreateTargetDataLayout(this);
 
     public readonly void EmitToFile(LLVMModuleRef module, string fileName, LLVMCodeGenFileType codegen) => EmitToFile(module, fileName.AsSpan(), codegen);

--- a/sources/LLVMSharp.Interop/Extensions/LLVMTargetRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMTargetRef.cs
@@ -75,6 +75,32 @@ public unsafe partial struct LLVMTargetRef(IntPtr handle) : IEquatable<LLVMTarge
         }
     }
 
+    public readonly string Description
+    {
+        get
+        {
+            if (Handle == IntPtr.Zero)
+            {
+                return string.Empty;
+            }
+
+            var pDescription = LLVM.GetTargetDescription(this);
+
+            if (pDescription == null)
+            {
+                return string.Empty;
+            }
+
+            return SpanExtensions.AsString(pDescription);
+        }
+    }
+
+    public readonly bool HasAsmBackend => (Handle != IntPtr.Zero) && LLVM.TargetHasAsmBackend(this) != 0;
+
+    public readonly bool HasJIT => (Handle != IntPtr.Zero) && LLVM.TargetHasJIT(this) != 0;
+
+    public readonly bool HasTargetMachine => (Handle != IntPtr.Zero) && LLVM.TargetHasTargetMachine(this) != 0;
+
     public readonly string Name
     {
         get

--- a/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
@@ -152,6 +152,38 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public readonly LLVMBasicBlockRef EntryBasicBlock => ((IsAFunction != null) && (BasicBlocksCount != 0)) ? LLVM.GetEntryBasicBlock(this) : default;
 
+    public readonly bool Exact
+    {
+        get
+        {
+            return InstructionOpcode is LLVMOpcode.LLVMUDiv or LLVMOpcode.LLVMSDiv or LLVMOpcode.LLVMLShr or LLVMOpcode.LLVMAShr && LLVM.GetExact(this) != 0;
+        }
+
+        set
+        {
+            if (InstructionOpcode is LLVMOpcode.LLVMUDiv or LLVMOpcode.LLVMSDiv or LLVMOpcode.LLVMLShr or LLVMOpcode.LLVMAShr)
+            {
+                LLVM.SetExact(this, value ? 1 : 0);
+            }
+        }
+    }
+
+    public readonly LLVMFastMathFlags FastMathFlags
+    {
+        get
+        {
+            return (LLVM.CanValueUseFastMathFlags(this) != 0) ? (LLVMFastMathFlags)LLVM.GetFastMathFlags(this) : default;
+        }
+
+        set
+        {
+            if (LLVM.CanValueUseFastMathFlags(this) != 0)
+            {
+                LLVM.SetFastMathFlags(this, (uint)value);
+            }
+        }
+    }
+
     public readonly LLVMRealPredicate FCmpPredicate => (Handle != IntPtr.Zero) ? LLVM.GetFCmpPredicate(this) : default;
 
     public readonly LLVMBasicBlockRef FirstBasicBlock => (IsAFunction != null) ? LLVM.GetFirstBasicBlock(this) : default;
@@ -201,6 +233,22 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
         }
     }
 
+    public readonly LLVMGEPNoWrapFlags GEPNoWrapFlags
+    {
+        get
+        {
+            return (IsAGetElementPtrInst != null) ? (LLVMGEPNoWrapFlags)LLVM.GEPGetNoWrapFlags(this) : default;
+        }
+
+        set
+        {
+            if (IsAGetElementPtrInst != null)
+            {
+                LLVM.GEPSetNoWrapFlags(this, (uint)value);
+            }
+        }
+    }
+
     public readonly LLVMTypeRef GEPSourceElementType => (IsAGetElementPtrInst != null) ? LLVM.GetGEPSourceElementType(this) : default;
 
     public readonly LLVMValueRef GlobalIFuncResolver
@@ -224,9 +272,37 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public readonly bool HasMetadata => (IsAInstruction != null) && LLVM.HasMetadata(this) != 0;
 
-    public readonly bool HasNoSignedWrap => (IsAInstruction != null) && llvmsharp.Instruction_hasNoSignedWrap(this) != 0;
+    public readonly bool HasNoSignedWrap
+    {
+        get
+        {
+            return InstructionOpcode is LLVMOpcode.LLVMAdd or LLVMOpcode.LLVMSub or LLVMOpcode.LLVMMul or LLVMOpcode.LLVMShl && LLVM.GetNSW(this) != 0;
+        }
 
-    public readonly bool HasNoUnsignedWrap => (IsAInstruction != null) && llvmsharp.Instruction_hasNoUnsignedWrap(this) != 0;
+        set
+        {
+            if (InstructionOpcode is LLVMOpcode.LLVMAdd or LLVMOpcode.LLVMSub or LLVMOpcode.LLVMMul or LLVMOpcode.LLVMShl)
+            {
+                LLVM.SetNSW(this, value ? 1 : 0);
+            }
+        }
+    }
+
+    public readonly bool HasNoUnsignedWrap
+    {
+        get
+        {
+            return InstructionOpcode is LLVMOpcode.LLVMAdd or LLVMOpcode.LLVMSub or LLVMOpcode.LLVMMul or LLVMOpcode.LLVMShl && LLVM.GetNUW(this) != 0;
+        }
+
+        set
+        {
+            if (InstructionOpcode is LLVMOpcode.LLVMAdd or LLVMOpcode.LLVMSub or LLVMOpcode.LLVMMul or LLVMOpcode.LLVMShl)
+            {
+                LLVM.SetNUW(this, value ? 1 : 0);
+            }
+        }
+    }
 
     public readonly bool HasPersonalityFn => (IsAFunction != null) && LLVM.HasPersonalityFn(this) != 0;
 
@@ -244,6 +320,22 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
     }
 
     public readonly LLVMIntPredicate ICmpPredicate => (Handle != IntPtr.Zero) ? LLVM.GetICmpPredicate(this) : default;
+
+    public readonly bool ICmpSameSign
+    {
+        get
+        {
+            return (IsAICmpInst != null) && LLVM.GetICmpSameSign(this) != 0;
+        }
+
+        set
+        {
+            if (IsAICmpInst != null)
+            {
+                LLVM.SetICmpSameSign(this, value ? 1 : 0);
+            }
+        }
+    }
 
     public readonly uint IncomingCount => (IsAPHINode != null) ? LLVM.CountIncoming(this) : default;
 
@@ -489,6 +581,22 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public readonly bool IsDeclaration => (IsAGlobalValue != null) && LLVM.IsDeclaration(this) != 0;
 
+    public readonly bool IsDisjoint
+    {
+        get
+        {
+            return InstructionOpcode is LLVMOpcode.LLVMOr && LLVM.GetIsDisjoint(this) != 0;
+        }
+
+        set
+        {
+            if (InstructionOpcode is LLVMOpcode.LLVMOr)
+            {
+                LLVM.SetIsDisjoint(this, value ? 1 : 0);
+            }
+        }
+    }
+
     public readonly bool IsExternallyInitialized
     {
         get
@@ -512,6 +620,22 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
         set
         {
             LLVM.SetGlobalConstant(this, value ? 1 : 0);
+        }
+    }
+
+    public readonly bool IsInBounds
+    {
+        get
+        {
+            return (IsAGetElementPtrInst != null) && LLVM.IsInBounds(this) != 0;
+        }
+
+        set
+        {
+            if (IsAGetElementPtrInst != null)
+            {
+                LLVM.SetIsInBounds(this, value ? 1 : 0);
+            }
         }
     }
 
@@ -605,6 +729,22 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
     public readonly LLVMValueRef NextInstruction => (IsAInstruction != null) ? LLVM.GetNextInstruction(this) : default;
 
     public readonly LLVMValueRef NextParam => (IsAArgument != null) ? LLVM.GetNextParam(this) : default;
+
+    public readonly bool NNeg
+    {
+        get
+        {
+            return InstructionOpcode is LLVMOpcode.LLVMZExt or LLVMOpcode.LLVMUIToFP && LLVM.GetNNeg(this) != 0;
+        }
+
+        set
+        {
+            if (InstructionOpcode is LLVMOpcode.LLVMZExt or LLVMOpcode.LLVMUIToFP)
+            {
+                LLVM.SetNNeg(this, value ? 1 : 0);
+            }
+        }
+    }
 
     public readonly LLVMBasicBlockRef NormalDest => (IsAInvokeInst != null) ? LLVM.GetNormalDest(this) : default;
 

--- a/sources/LLVMSharp/DataLayout.cs
+++ b/sources/LLVMSharp/DataLayout.cs
@@ -5,11 +5,45 @@ using LLVMSharp.Interop;
 
 namespace LLVMSharp;
 
-public sealed class DataLayout(ReadOnlySpan<char> stringRep) : IEquatable<DataLayout>
+public sealed class DataLayout : IEquatable<DataLayout>
 {
-    public LLVMTargetDataRef Handle { get; } = LLVMTargetDataRef.FromStringRepresentation(stringRep);
+    public DataLayout(ReadOnlySpan<char> stringRep)
+    {
+        Handle = LLVMTargetDataRef.FromStringRepresentation(stringRep);
+    }
+
+    internal DataLayout(LLVMTargetDataRef handle)
+    {
+        Handle = handle;
+    }
+
+    public LLVMTargetDataRef Handle { get; }
 
     public StructLayout GetStructLayout(StructType structType) => new StructLayout(this, structType);
+
+    public uint GetABITypeAlignment(Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        return Handle.ABIAlignmentOfType(type.Handle);
+    }
+
+    public uint GetCallFrameTypeAlignment(Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        return Handle.CallFrameAlignmentOfType(type.Handle);
+    }
+
+    public uint GetElementContainingOffset(StructType structType, ulong offset)
+    {
+        ArgumentNullException.ThrowIfNull(structType);
+        return (uint)Handle.ElementAtOffset(structType.Handle, offset);
+    }
+
+    public ulong GetOffsetOfElement(StructType structType, uint element)
+    {
+        ArgumentNullException.ThrowIfNull(structType);
+        return Handle.OffsetOfElement(structType.Handle, element);
+    }
 
     public ulong GetTypeSizeInBits(Type type)
     {
@@ -27,12 +61,6 @@ public sealed class DataLayout(ReadOnlySpan<char> stringRep) : IEquatable<DataLa
     {
         ArgumentNullException.ThrowIfNull(type);
         return Handle.ABISizeOfType(type.Handle);
-    }
-
-    public uint GetABITypeAlignment(Type type)
-    {
-        ArgumentNullException.ThrowIfNull(type);
-        return Handle.ABIAlignmentOfType(type.Handle);
     }
 
     public uint GetPrefTypeAlignment(Type type)

--- a/sources/LLVMSharp/LLVMContext.cs
+++ b/sources/LLVMSharp/LLVMContext.cs
@@ -17,6 +17,7 @@ public sealed class LLVMContext : IEquatable<LLVMContext>
 
     private readonly Dictionary<LLVMValueRef, WeakReference<Value>> _createdValues = [];
     private readonly Dictionary<LLVMTypeRef, WeakReference<Type>> _createdTypes = [];
+    private readonly Dictionary<LLVMModuleRef, WeakReference<Module>> _createdModules = [];
 
     public LLVMContext() : this(LLVMContextRef.Create())
     {
@@ -127,4 +128,26 @@ public sealed class LLVMContext : IEquatable<LLVMContext>
     internal Type GetOrCreate(LLVMTypeRef handle) => GetOrCreate<Type>(handle);
 
     internal Value GetOrCreate(LLVMValueRef handle) => GetOrCreate<Value>(handle);
+
+    internal Module GetOrCreate(LLVMModuleRef handle)
+    {
+        WeakReference<Module>? moduleRef;
+
+        if (handle == null)
+        {
+            return null!;
+        }
+        else if (!_createdModules.TryGetValue(handle, out moduleRef))
+        {
+            moduleRef = new WeakReference<Module>(null!);
+            _createdModules.Add(handle, moduleRef);
+        }
+
+        if (!moduleRef.TryGetTarget(out var module))
+        {
+            module = new Module(handle);
+            moduleRef.SetTarget(module);
+        }
+        return module;
+    }
 }

--- a/sources/LLVMSharp/Module.cs
+++ b/sources/LLVMSharp/Module.cs
@@ -1,13 +1,234 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
+using System.Collections.Generic;
 using LLVMSharp.Interop;
 
 namespace LLVMSharp;
 
 public sealed class Module : IEquatable<Module>
 {
+    internal Module(LLVMModuleRef handle)
+    {
+        Handle = handle;
+    }
+
     public LLVMModuleRef Handle { get; }
+
+    public LLVMContext Context => LLVMContext.GetOrCreate(Handle.Context);
+
+    public string DataLayoutString
+    {
+        get
+        {
+            return Handle.DataLayout;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.DataLayout = value;
+        }
+    }
+
+    public string InlineAsm
+    {
+        get
+        {
+            return Handle.InlineAsm;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.InlineAsm = value;
+        }
+    }
+
+    public string ModuleIdentifier
+    {
+        get
+        {
+            return Handle.ModuleIdentifier;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.ModuleIdentifier = value;
+        }
+    }
+
+    public string SourceFileName
+    {
+        get
+        {
+            return Handle.SourceFileName;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.SourceFileName = value;
+        }
+    }
+
+    public string TargetTriple
+    {
+        get
+        {
+            return Handle.Target;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.Target = value;
+        }
+    }
+
+    public static Module Create(LLVMContext context, string name)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return context.GetOrCreate(context.Handle.CreateModuleWithName(name));
+    }
+
+    public Module Clone() => Context.GetOrCreate(Handle.Clone());
+
+    public Function AddFunction(string name, FunctionType functionType)
+    {
+        ArgumentNullException.ThrowIfNull(functionType);
+        return Context.GetOrCreate<Function>(Handle.AddFunction(name, functionType.Handle));
+    }
+
+    public GlobalAlias AddAlias(Type valueType, uint addressSpace, Constant aliasee, string name)
+    {
+        ArgumentNullException.ThrowIfNull(valueType);
+        ArgumentNullException.ThrowIfNull(aliasee);
+        return Context.GetOrCreate<GlobalAlias>(Handle.AddAlias2(valueType.Handle, addressSpace, aliasee.Handle, name));
+    }
+
+    public GlobalVariable AddGlobal(Type type, string name)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        return Context.GetOrCreate<GlobalVariable>(Handle.AddGlobal(type.Handle, name));
+    }
+
+    public GlobalVariable AddGlobalInAddressSpace(Type type, string name, uint addressSpace)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        return Context.GetOrCreate<GlobalVariable>(Handle.AddGlobalInAddressSpace(type.Handle, name, addressSpace));
+    }
+
+    public void Dump() => Handle.Dump();
+
+    public Function? GetFunction(string name)
+    {
+        var handle = Handle.GetNamedFunction(name);
+        return (handle.Handle != IntPtr.Zero) ? Context.GetOrCreate<Function>(handle) : null;
+    }
+
+    public Function[] GetFunctions()
+    {
+        var result = new List<Function>();
+        var context = Context;
+
+        foreach (var handle in Handle.Functions)
+        {
+            result.Add(context.GetOrCreate<Function>(handle));
+        }
+
+        return [.. result];
+    }
+
+    public GlobalAlias[] GetGlobalAliases()
+    {
+        var result = new List<GlobalAlias>();
+        var context = Context;
+
+        foreach (var handle in Handle.GlobalAliases)
+        {
+            result.Add(context.GetOrCreate<GlobalAlias>(handle));
+        }
+
+        return [.. result];
+    }
+
+    public GlobalIFunc[] GetGlobalIFuncs()
+    {
+        var result = new List<GlobalIFunc>();
+        var context = Context;
+
+        foreach (var handle in Handle.GlobalIFuncs)
+        {
+            result.Add(context.GetOrCreate<GlobalIFunc>(handle));
+        }
+
+        return [.. result];
+    }
+
+    public GlobalVariable? GetGlobalVariable(string name)
+    {
+        var handle = Handle.GetNamedGlobal(name);
+        return (handle.Handle != IntPtr.Zero) ? Context.GetOrCreate<GlobalVariable>(handle) : null;
+    }
+
+    public GlobalVariable[] GetGlobalVariables()
+    {
+        var result = new List<GlobalVariable>();
+        var context = Context;
+
+        foreach (var handle in Handle.Globals)
+        {
+            result.Add(context.GetOrCreate<GlobalVariable>(handle));
+        }
+
+        return [.. result];
+    }
+
+    public StructType[] GetIdentifiedStructTypes()
+    {
+        var handles = Handle.GetIdentifiedStructTypes();
+
+        if (handles.Length == 0)
+        {
+            return [];
+        }
+
+        var context = Context;
+        var result = new StructType[handles.Length];
+
+        for (var i = 0; i < result.Length; i++)
+        {
+            result[i] = context.GetOrCreate<StructType>(handles[i]);
+        }
+
+        return result;
+    }
+
+    public Function GetOrInsertFunction(string name, FunctionType functionType)
+    {
+        ArgumentNullException.ThrowIfNull(functionType);
+        return GetFunction(name) ?? AddFunction(name, functionType);
+    }
+
+    public StructType? GetTypeByName(string name)
+    {
+        var handle = Handle.GetTypeByName(name);
+        return (handle.Handle != IntPtr.Zero) ? Context.GetOrCreate<StructType>(handle) : null;
+    }
+
+    public void PrintToFile(string filename) => Handle.PrintToFile(filename);
+
+    public string PrintToString() => Handle.PrintToString();
+
+    public bool TryPrintToFile(string filename, out string errorMessage) => Handle.TryPrintToFile(filename, out errorMessage);
+
+    public bool TryVerify(LLVMVerifierFailureAction action, out string message) => Handle.TryVerify(action, out message);
+
+    public void Verify(LLVMVerifierFailureAction action) => Handle.Verify(action);
+
+    public int WriteBitcodeToFile(string path) => Handle.WriteBitcodeToFile(path);
 
     public static bool operator ==(Module? left, Module? right) => ReferenceEquals(left, right) || (left?.Handle == right?.Handle);
 

--- a/sources/LLVMSharp/Target.cs
+++ b/sources/LLVMSharp/Target.cs
@@ -1,13 +1,61 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
+using System.Collections.Generic;
 using LLVMSharp.Interop;
 
 namespace LLVMSharp;
 
 public sealed class Target : IEquatable<Target>
 {
+    internal Target(LLVMTargetRef handle)
+    {
+        Handle = handle;
+    }
+
     public LLVMTargetRef Handle { get; }
+
+    public static string DefaultTriple => LLVMTargetRef.DefaultTriple;
+
+    public static IEnumerable<Target> Targets
+    {
+        get
+        {
+            foreach (var handle in LLVMTargetRef.Targets)
+            {
+                yield return new Target(handle);
+            }
+        }
+    }
+
+    public string Description => Handle.Description;
+
+    public bool HasAsmBackend => Handle.HasAsmBackend;
+
+    public bool HasJIT => Handle.HasJIT;
+
+    public bool HasTargetMachine => Handle.HasTargetMachine;
+
+    public string Name => Handle.Name;
+
+    public static Target GetTargetFromTriple(string triple) => new Target(LLVMTargetRef.GetTargetFromTriple(triple));
+
+    public static bool TryGetTargetFromTriple(string triple, out Target target, out string error)
+    {
+        if (LLVMTargetRef.TryGetTargetFromTriple(triple.AsSpan(), out var handle, out error))
+        {
+            target = new Target(handle);
+            return true;
+        }
+
+        target = null!;
+        return false;
+    }
+
+    public TargetMachine CreateTargetMachine(string triple, string cpu, string features, LLVMCodeGenOptLevel level, LLVMRelocMode reloc, LLVMCodeModel codeModel)
+    {
+        return new TargetMachine(Handle.CreateTargetMachine(triple, cpu, features, level, reloc, codeModel));
+    }
 
     public static bool operator ==(Target? left, Target? right) => ReferenceEquals(left, right) || (left?.Handle == right?.Handle);
 

--- a/sources/LLVMSharp/TargetMachine.cs
+++ b/sources/LLVMSharp/TargetMachine.cs
@@ -7,7 +7,34 @@ namespace LLVMSharp;
 
 public sealed class TargetMachine : IEquatable<TargetMachine>
 {
+    internal TargetMachine(LLVMTargetMachineRef handle)
+    {
+        Handle = handle;
+    }
+
     public LLVMTargetMachineRef Handle { get; }
+
+    public string CPU => Handle.CPU;
+
+    public string FeatureString => Handle.FeatureString;
+
+    public Target Target => new Target(Handle.Target);
+
+    public string Triple => Handle.Triple;
+
+    public DataLayout CreateTargetDataLayout() => new DataLayout(Handle.CreateTargetDataLayout());
+
+    public void EmitToFile(Module module, string fileName, LLVMCodeGenFileType codegen)
+    {
+        ArgumentNullException.ThrowIfNull(module);
+        Handle.EmitToFile(module.Handle, fileName, codegen);
+    }
+
+    public bool TryEmitToFile(Module module, string fileName, LLVMCodeGenFileType codegen, out string message)
+    {
+        ArgumentNullException.ThrowIfNull(module);
+        return Handle.TryEmitToFile(module.Handle, fileName, codegen, out message);
+    }
 
     public static bool operator ==(TargetMachine? left, TargetMachine? right) => ReferenceEquals(left, right) || (left?.Handle == right?.Handle);
 

--- a/sources/LLVMSharp/Values/BasicBlock.cs
+++ b/sources/LLVMSharp/Values/BasicBlock.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
+using System.Collections.Generic;
 using LLVMSharp.Interop;
 
 namespace LLVMSharp;
@@ -50,4 +51,87 @@ public sealed class BasicBlock : Value
     public new LLVMBasicBlockRef Handle { get; }
 
     public LLVMValueRef ValueHandle => base.Handle;
+
+    public Instruction? FirstInstruction
+    {
+        get
+        {
+            var handle = Handle.FirstInstruction;
+            return (handle.Handle != IntPtr.Zero) ? Context.GetOrCreate<Instruction>(handle) : null;
+        }
+    }
+
+    public Instruction? LastInstruction
+    {
+        get
+        {
+            var handle = Handle.LastInstruction;
+            return (handle.Handle != IntPtr.Zero) ? Context.GetOrCreate<Instruction>(handle) : null;
+        }
+    }
+
+    public BasicBlock? Next
+    {
+        get
+        {
+            var handle = Handle.Next;
+            return (handle.Handle != IntPtr.Zero) ? Context.GetOrCreate(handle) : null;
+        }
+    }
+
+    public Function? Parent
+    {
+        get
+        {
+            var handle = Handle.Parent;
+            return (handle.Handle != IntPtr.Zero) ? Context.GetOrCreate<Function>(handle) : null;
+        }
+    }
+
+    public BasicBlock? Previous
+    {
+        get
+        {
+            var handle = Handle.Previous;
+            return (handle.Handle != IntPtr.Zero) ? Context.GetOrCreate(handle) : null;
+        }
+    }
+
+    public Instruction? Terminator
+    {
+        get
+        {
+            var handle = Handle.Terminator;
+            return (handle.Handle != IntPtr.Zero) ? Context.GetOrCreate<Instruction>(handle) : null;
+        }
+    }
+
+    public void EraseFromParent() => Handle.Delete();
+
+    public Instruction[] GetInstructions()
+    {
+        var result = new List<Instruction>();
+        var context = Context;
+
+        foreach (var handle in Handle.Instructions)
+        {
+            result.Add(context.GetOrCreate<Instruction>(handle));
+        }
+
+        return [.. result];
+    }
+
+    public void MoveAfter(BasicBlock target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        Handle.MoveAfter(target.Handle);
+    }
+
+    public void MoveBefore(BasicBlock target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        Handle.MoveBefore(target.Handle);
+    }
+
+    public void RemoveFromParent() => Handle.RemoveFromParent();
 }

--- a/sources/LLVMSharp/Values/Users/Instructions/BinaryOperator.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/BinaryOperator.cs
@@ -9,4 +9,60 @@ public sealed class BinaryOperator : Instruction
     internal BinaryOperator(LLVMValueRef handle) : base(handle.IsABinaryOperator)
     {
     }
+
+    public bool HasNoSignedWrap
+    {
+        get
+        {
+            return Handle.HasNoSignedWrap;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.HasNoSignedWrap = value;
+        }
+    }
+
+    public bool HasNoUnsignedWrap
+    {
+        get
+        {
+            return Handle.HasNoUnsignedWrap;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.HasNoUnsignedWrap = value;
+        }
+    }
+
+    public bool IsDisjoint
+    {
+        get
+        {
+            return Handle.IsDisjoint;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.IsDisjoint = value;
+        }
+    }
+
+    public bool IsExact
+    {
+        get
+        {
+            return Handle.Exact;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.Exact = value;
+        }
+    }
 }

--- a/sources/LLVMSharp/Values/Users/Instructions/CallBase.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/CallBase.cs
@@ -48,6 +48,8 @@ public class CallBase : Instruction
 
     public FunctionType CalledFunctionType => Context.GetOrCreate<FunctionType>(Handle.CalledFunctionType);
 
+    public Function? CalledFunction => CalledOperand as Function;
+
     public Value CalledOperand => Context.GetOrCreate(Handle.CalledValue);
 
     public Value GetArgOperand(uint index) => Context.GetOrCreate(Handle.GetArgOperand(index));

--- a/sources/LLVMSharp/Values/Users/Instructions/GetElementPtrInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/GetElementPtrInst.cs
@@ -10,5 +10,39 @@ public sealed class GetElementPtrInst : Instruction
     {
     }
 
+    public bool IsInBounds
+    {
+        get
+        {
+            return Handle.IsInBounds;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.IsInBounds = value;
+        }
+    }
+
+    public LLVMGEPNoWrapFlags NoWrapFlags
+    {
+        get
+        {
+            return Handle.GEPNoWrapFlags;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.GEPNoWrapFlags = value;
+        }
+    }
+
+    public uint NumIndices => NumOperands - 1;
+
+    public Value PointerOperand => GetOperand(0);
+
+    public Type PointerOperandType => PointerOperand.Type;
+
     public Type SourceElementType => Context.GetOrCreate(Handle.GEPSourceElementType);
 }

--- a/sources/LLVMSharp/Values/Users/Instructions/ICmpInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/ICmpInst.cs
@@ -9,4 +9,18 @@ public sealed class ICmpInst : CmpInst
     internal ICmpInst(LLVMValueRef handle) : base(handle.IsAICmpInst)
     {
     }
+
+    public bool HasSameSign
+    {
+        get
+        {
+            return Handle.ICmpSameSign;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.ICmpSameSign = value;
+        }
+    }
 }

--- a/sources/LLVMSharp/Values/Users/Instructions/Instruction.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/Instruction.cs
@@ -11,6 +11,20 @@ public partial class Instruction : User
     {
     }
 
+    public LLVMFastMathFlags FastMathFlags
+    {
+        get
+        {
+            return Handle.FastMathFlags;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.FastMathFlags = value;
+        }
+    }
+
     public bool IsTerminator => Handle.IsATerminatorInst != null;
 
     public LLVMOpcode Opcode => Handle.InstructionOpcode;

--- a/sources/LLVMSharp/Values/Users/Instructions/LoadInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/LoadInst.cs
@@ -50,4 +50,6 @@ public sealed class LoadInst : UnaryInstruction
             handle.Volatile = value;
         }
     }
+
+    public Value PointerOperand => GetOperand(0);
 }

--- a/sources/LLVMSharp/Values/Users/Instructions/StoreInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/StoreInst.cs
@@ -50,4 +50,8 @@ public sealed class StoreInst : Instruction
             handle.Volatile = value;
         }
     }
+
+    public Value PointerOperand => GetOperand(1);
+
+    public Value ValueOperand => GetOperand(0);
 }

--- a/sources/LLVMSharp/Values/Users/Instructions/ZExtInst.cs
+++ b/sources/LLVMSharp/Values/Users/Instructions/ZExtInst.cs
@@ -9,4 +9,18 @@ public sealed class ZExtInst : CastInst
     internal ZExtInst(LLVMValueRef handle) : base(handle.IsAZExtInst)
     {
     }
+
+    public bool IsNonNeg
+    {
+        get
+        {
+            return Handle.NNeg;
+        }
+
+        set
+        {
+            var handle = Handle;
+            handle.NNeg = value;
+        }
+    }
 }

--- a/tests/LLVMSharp.UnitTests/ManagedApi.cs
+++ b/tests/LLVMSharp.UnitTests/ManagedApi.cs
@@ -473,4 +473,58 @@ public class ManagedApi
         Assert.That(next.Previous, Is.EqualTo(entry));
         Assert.That(next.Terminator, Is.Null);
     }
+
+    [Test]
+    public void InstructionFlagAccessors()
+    {
+        var context = new LLVMContext();
+        var module = Module.Create(context, "m");
+        var int32 = Type.GetInt32Ty(context);
+        var int64 = Type.GetInt64Ty(context);
+        var flt = Type.GetFloatTy(context);
+
+        var functionType = LLVMTypeRef.CreateFunction(Type.GetVoidTy(context).Handle, [int32.Handle, int32.Handle, flt.Handle, flt.Handle], IsVarArg: false);
+        var function = module.AddFunction("f", (FunctionType)context.GetOrCreate(functionType));
+        var entry = function.AppendBasicBlock("entry");
+
+        using var builder = LLVMBuilderRef.Create(context.Handle);
+        builder.PositionAtEnd(entry.Handle);
+
+        var lhs = function.GetParam(0).Handle;
+        var rhs = function.GetParam(1).Handle;
+
+        var add = (BinaryOperator)context.GetOrCreate(builder.BuildAdd(lhs, rhs, "add"));
+        add.HasNoSignedWrap = true;
+        add.HasNoUnsignedWrap = true;
+        Assert.That(add.HasNoSignedWrap, Is.True);
+        Assert.That(add.HasNoUnsignedWrap, Is.True);
+
+        var div = (BinaryOperator)context.GetOrCreate(builder.BuildUDiv(lhs, rhs, "div"));
+        div.IsExact = true;
+        Assert.That(div.IsExact, Is.True);
+
+        var disjoint = (BinaryOperator)context.GetOrCreate(builder.BuildOr(lhs, rhs, "or"));
+        disjoint.IsDisjoint = true;
+        Assert.That(disjoint.IsDisjoint, Is.True);
+
+        var zext = (ZExtInst)context.GetOrCreate(builder.BuildZExt(lhs, int64.Handle, "zext"));
+        zext.IsNonNeg = true;
+        Assert.That(zext.IsNonNeg, Is.True);
+
+        var icmp = (ICmpInst)context.GetOrCreate(builder.BuildICmp(LLVMIntPredicate.LLVMIntSLT, lhs, rhs, "cmp"));
+        icmp.HasSameSign = true;
+        Assert.That(icmp.HasSameSign, Is.True);
+
+        var fadd = (Instruction)context.GetOrCreate(builder.BuildFAdd(function.GetParam(2).Handle, function.GetParam(3).Handle, "fadd"));
+        fadd.FastMathFlags = LLVMFastMathFlags.LLVMFastMathAll;
+        Assert.That(fadd.FastMathFlags, Is.EqualTo(LLVMFastMathFlags.LLVMFastMathAll));
+
+        var arrayType = LLVMTypeRef.CreateArray(int32.Handle, 4);
+        var storage = builder.BuildAlloca(arrayType, "arr");
+        var gep = (GetElementPtrInst)context.GetOrCreate(builder.BuildGEP2(arrayType, storage, new[] { LLVMValueRef.CreateConstInt(int32.Handle, 0), LLVMValueRef.CreateConstInt(int32.Handle, 1) }, "elem"));
+        gep.IsInBounds = true;
+        Assert.That(gep.IsInBounds, Is.True);
+        Assert.That(gep.NumIndices, Is.EqualTo(2u));
+        Assert.That(gep.PointerOperand, Is.EqualTo(context.GetOrCreate(storage)));
+    }
 }

--- a/tests/LLVMSharp.UnitTests/ManagedApi.cs
+++ b/tests/LLVMSharp.UnitTests/ManagedApi.cs
@@ -445,4 +445,32 @@ public class ManagedApi
         var clone = module.Clone();
         Assert.That(clone.GetFunction("f"), Is.Not.Null);
     }
+
+    [Test]
+    public void BasicBlockAccessors()
+    {
+        var context = new LLVMContext();
+        var module = Module.Create(context, "m");
+        var int32 = Type.GetInt32Ty(context);
+
+        var functionType = LLVMTypeRef.CreateFunction(int32.Handle, [int32.Handle], IsVarArg: false);
+        var function = module.AddFunction("f", (FunctionType)context.GetOrCreate(functionType));
+        var entry = function.AppendBasicBlock("entry");
+        var next = function.AppendBasicBlock("next");
+
+        using var builder = LLVMBuilderRef.Create(context.Handle);
+        builder.PositionAtEnd(entry.Handle);
+
+        var addHandle = builder.BuildAdd(function.GetParam(0).Handle, function.GetParam(0).Handle, "sum");
+        var retHandle = builder.BuildRet(addHandle);
+
+        Assert.That(entry.Parent, Is.EqualTo(function));
+        Assert.That(entry.Terminator, Is.EqualTo(context.GetOrCreate(retHandle)));
+        Assert.That(entry.FirstInstruction, Is.EqualTo(context.GetOrCreate(addHandle)));
+        Assert.That(entry.LastInstruction, Is.EqualTo(context.GetOrCreate(retHandle)));
+        Assert.That(entry.GetInstructions().Length, Is.EqualTo(2));
+        Assert.That(entry.Next, Is.EqualTo(next));
+        Assert.That(next.Previous, Is.EqualTo(entry));
+        Assert.That(next.Terminator, Is.Null);
+    }
 }

--- a/tests/LLVMSharp.UnitTests/ManagedApi.cs
+++ b/tests/LLVMSharp.UnitTests/ManagedApi.cs
@@ -527,4 +527,41 @@ public class ManagedApi
         Assert.That(gep.NumIndices, Is.EqualTo(2u));
         Assert.That(gep.PointerOperand, Is.EqualTo(context.GetOrCreate(storage)));
     }
+
+    [Test]
+    public void TargetAndTargetMachineAccessors()
+    {
+        LLVM.InitializeAllTargetInfos();
+        LLVM.InitializeAllTargets();
+        LLVM.InitializeAllTargetMCs();
+
+        var triple = Target.DefaultTriple;
+        Assert.That(triple, Is.Not.Empty);
+
+        var target = Target.GetTargetFromTriple(triple);
+        Assert.That(target.Name, Is.Not.Empty);
+        Assert.That(target.Description, Is.Not.Null);
+
+        var targetMachine = target.CreateTargetMachine(triple, "", "", LLVMCodeGenOptLevel.LLVMCodeGenLevelDefault, LLVMRelocMode.LLVMRelocDefault, LLVMCodeModel.LLVMCodeModelDefault);
+        Assert.That(targetMachine.Triple, Is.EqualTo(triple));
+        Assert.That(targetMachine.Target, Is.EqualTo(target));
+
+        var dataLayout = targetMachine.CreateTargetDataLayout();
+        var context = new LLVMContext();
+        Assert.That(dataLayout.GetTypeSizeInBits(Type.GetInt32Ty(context)), Is.EqualTo(32ul));
+    }
+
+    [Test]
+    public void DataLayoutAccessors()
+    {
+        var context = new LLVMContext();
+        var dataLayout = new DataLayout("e-m:w-p:64:64-i64:64-n8:16:32:64");
+
+        var structType = StructType.Create(context, "S");
+        structType.SetBody([Type.GetInt32Ty(context), Type.GetInt64Ty(context)], packed: false);
+
+        Assert.That(dataLayout.GetTypeSizeInBits(Type.GetInt64Ty(context)), Is.EqualTo(64ul));
+        Assert.That(dataLayout.GetOffsetOfElement(structType, 1), Is.EqualTo(8ul));
+        Assert.That(dataLayout.GetElementContainingOffset(structType, 8), Is.EqualTo(1u));
+    }
 }

--- a/tests/LLVMSharp.UnitTests/ManagedApi.cs
+++ b/tests/LLVMSharp.UnitTests/ManagedApi.cs
@@ -403,4 +403,46 @@ public class ManagedApi
         var fence = (FenceInst)context.GetOrCreate(builder.BuildFence(LLVMAtomicOrdering.LLVMAtomicOrderingAcquire, singleThread: false, "fence"));
         Assert.That(fence.Ordering, Is.EqualTo(AtomicOrdering.Acquire));
     }
+
+    [Test]
+    public void ModuleAccessors()
+    {
+        var context = new LLVMContext();
+        var module = Module.Create(context, "m");
+        var int32 = Type.GetInt32Ty(context);
+
+        Assert.That(module.ModuleIdentifier, Is.EqualTo("m"));
+        Assert.That(module.Context, Is.EqualTo(context));
+
+        module.SourceFileName = "source.ll";
+        module.TargetTriple = "x86_64-pc-windows-msvc";
+        module.DataLayoutString = "e-m:w-p:64:64";
+        module.InlineAsm = "nop";
+
+        Assert.That(module.SourceFileName, Is.EqualTo("source.ll"));
+        Assert.That(module.TargetTriple, Is.EqualTo("x86_64-pc-windows-msvc"));
+        Assert.That(module.DataLayoutString, Is.EqualTo("e-m:w-p:64:64"));
+        Assert.That(module.InlineAsm, Does.Contain("nop"));
+
+        var functionType = LLVMTypeRef.CreateFunction(int32.Handle, [int32.Handle], IsVarArg: false);
+        var function = module.AddFunction("f", (FunctionType)context.GetOrCreate(functionType));
+        var global = module.AddGlobal(int32, "g");
+
+        Assert.That(module.GetFunction("f"), Is.EqualTo(function));
+        Assert.That(module.GetFunction("missing"), Is.Null);
+        Assert.That(module.GetGlobalVariable("g"), Is.EqualTo(global));
+        Assert.That(module.GetOrInsertFunction("f", (FunctionType)context.GetOrCreate(functionType)), Is.EqualTo(function));
+        Assert.That(module.GetFunctions().Length, Is.EqualTo(1));
+        Assert.That(module.GetGlobalVariables().Length, Is.EqualTo(1));
+
+        var structType = StructType.Create(context, "S");
+        structType.SetBody([int32], packed: false);
+        _ = module.AddGlobal(structType, "s");
+        Assert.That(module.GetTypeByName("S"), Is.EqualTo(structType));
+
+        Assert.That(module.TryVerify(LLVMVerifierFailureAction.LLVMReturnStatusAction, out _), Is.True);
+
+        var clone = module.Clone();
+        Assert.That(clone.GetFunction("f"), Is.Not.Null);
+    }
 }


### PR DESCRIPTION
Expands the high-level managed API (`sources/LLVMSharp`) to cover the
Phase-1 gaps that don't depend on new native `libLLVMSharp` helpers, moving
it closer to a faithful reproduction of the LLVM C++ API a real compiler or
JIT needs. Split into four logical commits by area.

----------

**Module** -- adds a context-scoped ownership registry to `LLVMContext` so a
`Module` is a cached, non-owning wrapper (consistent with the other managed
value/type wrappers), and fills out the full accessor set: identity, source
file name, target triple, data-layout string, module inline asm; function and
global lookup/insertion/enumeration; named struct-type lookup; and
print/verify/clone/bitcode. Also exposes `ModuleIdentifier`,
`SourceFileName`, and `InlineAsm` on `LLVMModuleRef`.

**BasicBlock** -- parent, terminator, first/last instruction, next/previous
block, instruction enumeration, and move/remove/erase helpers.

**Instruction flags + derived accessors** -- round-trips the poison-generating
and fast-math flags through the C API instead of native helpers:
`HasNoSignedWrap`/`HasNoUnsignedWrap` move onto `LLVMGetNSW`/`GetNUW`
with setters, and `Exact`, disjoint, non-negative, GEP no-wrap, in-bounds,
icmp same-sign, and fast-math flags are added -- each guarded by the owning
instruction kind so a release build never reads the wrong `SubclassOptionalData`
bits. Also adds the trivially-derived `CalledFunction`, GEP index/pointer
operands, and load/store pointer/value operands (no new interop).

**Target / TargetMachine / DataLayout** -- description, JIT/target-machine/
asm-backend queries, and target enumeration on `Target`; CPU, feature string,
target, and triple on `TargetMachine`; a target-data constructor plus
call-frame alignment, element offset, and element-containing-offset on
`DataLayout`. Adds the matching getters on `LLVMTargetRef` and
`LLVMTargetMachineRef`.

----------

Builds clean (0 warnings, `TreatWarningsAsErrors`) with 5 new managed tests;
full suite green. This is the managed half; the native `libLLVMSharp` helpers
and the managed accessors that consume them follow separately once the native
packages are rebuilt.
