### PR TITLE
Wrap remaining CORE C-API accessors on the Layer-2 typed handles

### DIFF
--- a/sources/LLVMSharp.Interop/Extensions/LLVM.Manual.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVM.Manual.cs
@@ -32,6 +32,17 @@ public static unsafe partial class LLVM
         return new ReadOnlySpan<byte>(filename, (int)length).AsString();
     }
 
+    public static string DIFileGetSource(LLVMMetadataRef file)
+    {
+        uint length = 0;
+        sbyte* source = DIFileGetSource(file, &length);
+        if (source == null)
+        {
+            return "";
+        }
+        return new ReadOnlySpan<byte>(source, (int)length).AsString();
+    }
+
     public static string DITypeGetName(LLVMMetadataRef type)
     {
         nuint length = 0;

--- a/sources/LLVMSharp.Interop/Extensions/LLVMBasicBlockRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMBasicBlockRef.cs
@@ -14,6 +14,8 @@ public unsafe partial struct LLVMBasicBlockRef(IntPtr handle) : IEquatable<LLVMB
 
     public readonly LLVMValueRef LastInstruction => (Handle != IntPtr.Zero) ? LLVM.GetLastInstruction(this) : default;
 
+    public readonly string Name => (Handle != IntPtr.Zero) ? SpanExtensions.AsString(LLVM.GetBasicBlockName(this)) : string.Empty;
+
     public readonly LLVMBasicBlockRef Next => (Handle != IntPtr.Zero) ? LLVM.GetNextBasicBlock(this) : default;
 
     public readonly LLVMValueRef Parent => (Handle != IntPtr.Zero) ? LLVM.GetBasicBlockParent(this) : default;

--- a/sources/LLVMSharp.Interop/Extensions/LLVMBuilderRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMBuilderRef.cs
@@ -8,6 +8,8 @@ public unsafe partial struct LLVMBuilderRef(IntPtr handle) : IDisposable, IEquat
 {
     public IntPtr Handle = handle;
 
+    public readonly LLVMContextRef Context => (Handle != IntPtr.Zero) ? LLVM.GetBuilderContext(this) : default;
+
     public readonly LLVMValueRef CurrentDebugLocation
     {
         get
@@ -18,6 +20,32 @@ public unsafe partial struct LLVMBuilderRef(IntPtr handle) : IDisposable, IEquat
         set
         {
             LLVM.SetCurrentDebugLocation(this, value);
+        }
+    }
+
+    public readonly LLVMMetadataRef CurrentDebugLocation2
+    {
+        get
+        {
+            return (Handle != IntPtr.Zero) ? LLVM.GetCurrentDebugLocation2(this) : default;
+        }
+
+        set
+        {
+            LLVM.SetCurrentDebugLocation2(this, value);
+        }
+    }
+
+    public readonly LLVMMetadataRef DefaultFPMathTag
+    {
+        get
+        {
+            return (Handle != IntPtr.Zero) ? LLVM.BuilderGetDefaultFPMathTag(this) : default;
+        }
+
+        set
+        {
+            LLVM.BuilderSetDefaultFPMathTag(this, value);
         }
     }
 
@@ -32,6 +60,8 @@ public unsafe partial struct LLVMBuilderRef(IntPtr handle) : IDisposable, IEquat
     public static bool operator !=(LLVMBuilderRef left, LLVMBuilderRef right) => !(left == right);
 
     public static LLVMBuilderRef Create(LLVMContextRef C) => LLVM.CreateBuilderInContext(C);
+
+    public readonly void AddMetadataToInst(LLVMValueRef Inst) => LLVM.AddMetadataToInst(this, Inst);
 
     public readonly LLVMValueRef BuildAdd(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildAdd(LHS, RHS, Name.AsSpan());
 
@@ -99,7 +129,13 @@ public unsafe partial struct LLVMBuilderRef(IntPtr handle) : IDisposable, IEquat
         return LLVM.BuildAShr(this, LHS, RHS, marshaledName);
     }
 
+    public readonly LLVMValueRef BuildAtomicCmpXchg(LLVMValueRef Ptr, LLVMValueRef Cmp, LLVMValueRef New, LLVMAtomicOrdering SuccessOrdering, LLVMAtomicOrdering FailureOrdering, bool SingleThread) => LLVM.BuildAtomicCmpXchg(this, Ptr, Cmp, New, SuccessOrdering, FailureOrdering, SingleThread ? 1 : 0);
+
+    public readonly LLVMValueRef BuildAtomicCmpXchgSyncScope(LLVMValueRef Ptr, LLVMValueRef Cmp, LLVMValueRef New, LLVMAtomicOrdering SuccessOrdering, LLVMAtomicOrdering FailureOrdering, uint SSID) => LLVM.BuildAtomicCmpXchgSyncScope(this, Ptr, Cmp, New, SuccessOrdering, FailureOrdering, SSID);
+
     public readonly LLVMValueRef BuildAtomicRMW(LLVMAtomicRMWBinOp op, LLVMValueRef PTR, LLVMValueRef Val, LLVMAtomicOrdering ordering, bool singleThread) => LLVM.BuildAtomicRMW(this, op, PTR, Val, ordering, singleThread ? 1 : 0);
+
+    public readonly LLVMValueRef BuildAtomicRMWSyncScope(LLVMAtomicRMWBinOp op, LLVMValueRef PTR, LLVMValueRef Val, LLVMAtomicOrdering ordering, uint SSID) => LLVM.BuildAtomicRMWSyncScope(this, op, PTR, Val, ordering, SSID);
 
     public readonly LLVMValueRef BuildBinOp(LLVMOpcode Op, LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildBinOp(Op, LHS, RHS, Name.AsSpan());
 
@@ -130,6 +166,31 @@ public unsafe partial struct LLVMBuilderRef(IntPtr handle) : IDisposable, IEquat
         }
     }
 
+    public readonly LLVMValueRef BuildCallBr(LLVMTypeRef Ty, LLVMValueRef Fn, LLVMBasicBlockRef DefaultDest, LLVMBasicBlockRef[] IndirectDests, LLVMValueRef[] Args, LLVMOperandBundleRef[] Bundles, string Name = "") => BuildCallBr(Ty, Fn, DefaultDest, IndirectDests.AsSpan(), Args.AsSpan(), Bundles.AsSpan(), Name.AsSpan());
+
+    public readonly LLVMValueRef BuildCallBr(LLVMTypeRef Ty, LLVMValueRef Fn, LLVMBasicBlockRef DefaultDest, ReadOnlySpan<LLVMBasicBlockRef> IndirectDests, ReadOnlySpan<LLVMValueRef> Args, ReadOnlySpan<LLVMOperandBundleRef> Bundles, ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        fixed (LLVMBasicBlockRef* pIndirectDests = IndirectDests)
+        fixed (LLVMValueRef* pArgs = Args)
+        fixed (LLVMOperandBundleRef* pBundles = Bundles)
+        {
+            return LLVM.BuildCallBr(this, Ty, Fn, DefaultDest, (LLVMOpaqueBasicBlock**)pIndirectDests, (uint)IndirectDests.Length, (LLVMOpaqueValue**)pArgs, (uint)Args.Length, (LLVMOpaqueOperandBundle**)pBundles, (uint)Bundles.Length, marshaledName);
+        }
+    }
+
+    public readonly LLVMValueRef BuildCallWithOperandBundles(LLVMTypeRef Ty, LLVMValueRef Fn, LLVMValueRef[] Args, LLVMOperandBundleRef[] Bundles, string Name = "") => BuildCallWithOperandBundles(Ty, Fn, Args.AsSpan(), Bundles.AsSpan(), Name.AsSpan());
+
+    public readonly LLVMValueRef BuildCallWithOperandBundles(LLVMTypeRef Ty, LLVMValueRef Fn, ReadOnlySpan<LLVMValueRef> Args, ReadOnlySpan<LLVMOperandBundleRef> Bundles, ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        fixed (LLVMValueRef* pArgs = Args)
+        fixed (LLVMOperandBundleRef* pBundles = Bundles)
+        {
+            return LLVM.BuildCallWithOperandBundles(this, Ty, Fn, (LLVMOpaqueValue**)pArgs, (uint)Args.Length, (LLVMOpaqueOperandBundle**)pBundles, (uint)Bundles.Length, marshaledName);
+        }
+    }
+
     public readonly LLVMValueRef BuildCast(LLVMOpcode Op, LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildCast(Op, Val, DestTy, Name.AsSpan());
 
     public readonly LLVMValueRef BuildCast(LLVMOpcode Op, LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
@@ -137,6 +198,40 @@ public unsafe partial struct LLVMBuilderRef(IntPtr handle) : IDisposable, IEquat
         using var marshaledName = new MarshaledString(Name);
         return LLVM.BuildCast(this, Op, Val, DestTy, marshaledName);
     }
+
+    public readonly LLVMValueRef BuildCatchPad(LLVMValueRef ParentPad, LLVMValueRef[] Args, string Name = "") => BuildCatchPad(ParentPad, Args.AsSpan(), Name.AsSpan());
+
+    public readonly LLVMValueRef BuildCatchPad(LLVMValueRef ParentPad, ReadOnlySpan<LLVMValueRef> Args, ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        fixed (LLVMValueRef* pArgs = Args)
+        {
+            return LLVM.BuildCatchPad(this, ParentPad, (LLVMOpaqueValue**)pArgs, (uint)Args.Length, marshaledName);
+        }
+    }
+
+    public readonly LLVMValueRef BuildCatchRet(LLVMValueRef CatchPad, LLVMBasicBlockRef BB) => LLVM.BuildCatchRet(this, CatchPad, BB);
+
+    public readonly LLVMValueRef BuildCatchSwitch(LLVMValueRef ParentPad, LLVMBasicBlockRef UnwindBB, uint NumHandlers, string Name = "") => BuildCatchSwitch(ParentPad, UnwindBB, NumHandlers, Name.AsSpan());
+
+    public readonly LLVMValueRef BuildCatchSwitch(LLVMValueRef ParentPad, LLVMBasicBlockRef UnwindBB, uint NumHandlers, ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        return LLVM.BuildCatchSwitch(this, ParentPad, UnwindBB, NumHandlers, marshaledName);
+    }
+
+    public readonly LLVMValueRef BuildCleanupPad(LLVMValueRef ParentPad, LLVMValueRef[] Args, string Name = "") => BuildCleanupPad(ParentPad, Args.AsSpan(), Name.AsSpan());
+
+    public readonly LLVMValueRef BuildCleanupPad(LLVMValueRef ParentPad, ReadOnlySpan<LLVMValueRef> Args, ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        fixed (LLVMValueRef* pArgs = Args)
+        {
+            return LLVM.BuildCleanupPad(this, ParentPad, (LLVMOpaqueValue**)pArgs, (uint)Args.Length, marshaledName);
+        }
+    }
+
+    public readonly LLVMValueRef BuildCleanupRet(LLVMValueRef CatchPad, LLVMBasicBlockRef BB) => LLVM.BuildCleanupRet(this, CatchPad, BB);
 
     public readonly LLVMValueRef BuildCondBr(LLVMValueRef If, LLVMBasicBlockRef Then, LLVMBasicBlockRef Else) => LLVM.BuildCondBr(this, If, Then, Else);
 
@@ -146,6 +241,14 @@ public unsafe partial struct LLVMBuilderRef(IntPtr handle) : IDisposable, IEquat
     {
         using var marshaledName = new MarshaledString(Name);
         return LLVM.BuildExactSDiv(this, LHS, RHS, marshaledName);
+    }
+
+    public readonly LLVMValueRef BuildExactUDiv(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildExactUDiv(LHS, RHS, Name.AsSpan());
+
+    public readonly LLVMValueRef BuildExactUDiv(LLVMValueRef LHS, LLVMValueRef RHS, ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        return LLVM.BuildExactUDiv(this, LHS, RHS, marshaledName);
     }
 
     public readonly LLVMValueRef BuildExtractElement(LLVMValueRef VecVal, LLVMValueRef Index, string Name = "") => BuildExtractElement(VecVal, Index, Name.AsSpan());
@@ -194,6 +297,14 @@ public unsafe partial struct LLVMBuilderRef(IntPtr handle) : IDisposable, IEquat
     {
         using var marshaledName = new MarshaledString(Name);
         return LLVM.BuildFence(this, ordering, singleThread ? 1 : 0, marshaledName);
+    }
+
+    public readonly LLVMValueRef BuildFenceSyncScope(LLVMAtomicOrdering ordering, uint SSID, string Name = "") => BuildFenceSyncScope(ordering, SSID, Name.AsSpan());
+
+    public readonly LLVMValueRef BuildFenceSyncScope(LLVMAtomicOrdering ordering, uint SSID, ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        return LLVM.BuildFenceSyncScope(this, ordering, SSID, marshaledName);
     }
 
     public readonly LLVMValueRef BuildFMul(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildFMul(LHS, RHS, Name.AsSpan());
@@ -289,6 +400,17 @@ public unsafe partial struct LLVMBuilderRef(IntPtr handle) : IDisposable, IEquat
         }
     }
 
+    public readonly LLVMValueRef BuildGEPWithNoWrapFlags(LLVMTypeRef Ty, LLVMValueRef Pointer, LLVMValueRef[] Indices, LLVMGEPNoWrapFlags NoWrapFlags, string Name = "") => BuildGEPWithNoWrapFlags(Ty, Pointer, Indices.AsSpan(), NoWrapFlags, Name.AsSpan());
+
+    public readonly LLVMValueRef BuildGEPWithNoWrapFlags(LLVMTypeRef Ty, LLVMValueRef Pointer, ReadOnlySpan<LLVMValueRef> Indices, LLVMGEPNoWrapFlags NoWrapFlags, ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        fixed (LLVMValueRef* pIndices = Indices)
+        {
+            return LLVM.BuildGEPWithNoWrapFlags(this, Ty, Pointer, (LLVMOpaqueValue**)pIndices, (uint)Indices.Length, marshaledName, (uint)NoWrapFlags);
+        }
+    }
+
     public readonly LLVMValueRef BuildGlobalString(string Str, string Name = "") => BuildGlobalString(Str.AsSpan(), Name.AsSpan());
 
     public readonly LLVMValueRef BuildGlobalString(ReadOnlySpan<char> Str, ReadOnlySpan<char> Name)
@@ -352,6 +474,14 @@ public unsafe partial struct LLVMBuilderRef(IntPtr handle) : IDisposable, IEquat
         return LLVM.BuildIntCast(this, Val, DestTy, marshaledName);
     }
 
+    public readonly LLVMValueRef BuildIntCast2(LLVMValueRef Val, LLVMTypeRef DestTy, bool IsSigned, string Name = "") => BuildIntCast2(Val, DestTy, IsSigned, Name.AsSpan());
+
+    public readonly LLVMValueRef BuildIntCast2(LLVMValueRef Val, LLVMTypeRef DestTy, bool IsSigned, ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        return LLVM.BuildIntCast2(this, Val, DestTy, IsSigned ? 1 : 0, marshaledName);
+    }
+
     public readonly LLVMValueRef BuildIntToPtr(LLVMValueRef Val, LLVMTypeRef DestTy, string Name = "") => BuildIntToPtr(Val, DestTy, Name.AsSpan());
 
     public readonly LLVMValueRef BuildIntToPtr(LLVMValueRef Val, LLVMTypeRef DestTy, ReadOnlySpan<char> Name)
@@ -368,6 +498,18 @@ public unsafe partial struct LLVMBuilderRef(IntPtr handle) : IDisposable, IEquat
         {
             using var marshaledName = new MarshaledString(Name);
             return LLVM.BuildInvoke2(this, Ty, Fn, (LLVMOpaqueValue**)pArgs, (uint)Args.Length, Then, Catch, marshaledName);
+        }
+    }
+
+    public readonly LLVMValueRef BuildInvokeWithOperandBundles(LLVMTypeRef Ty, LLVMValueRef Fn, LLVMValueRef[] Args, LLVMBasicBlockRef Then, LLVMBasicBlockRef Catch, LLVMOperandBundleRef[] Bundles, string Name = "") => BuildInvokeWithOperandBundles(Ty, Fn, Args.AsSpan(), Then, Catch, Bundles.AsSpan(), Name.AsSpan());
+
+    public readonly LLVMValueRef BuildInvokeWithOperandBundles(LLVMTypeRef Ty, LLVMValueRef Fn, ReadOnlySpan<LLVMValueRef> Args, LLVMBasicBlockRef Then, LLVMBasicBlockRef Catch, ReadOnlySpan<LLVMOperandBundleRef> Bundles, ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        fixed (LLVMValueRef* pArgs = Args)
+        fixed (LLVMOperandBundleRef* pBundles = Bundles)
+        {
+            return LLVM.BuildInvokeWithOperandBundles(this, Ty, Fn, (LLVMOpaqueValue**)pArgs, (uint)Args.Length, Then, Catch, (LLVMOpaqueOperandBundle**)pBundles, (uint)Bundles.Length, marshaledName);
         }
     }
 
@@ -418,6 +560,12 @@ public unsafe partial struct LLVMBuilderRef(IntPtr handle) : IDisposable, IEquat
         using var marshaledName = new MarshaledString(Name);
         return LLVM.BuildMalloc(this, Ty, marshaledName);
     }
+
+    public readonly LLVMValueRef BuildMemCpy(LLVMValueRef Dst, uint DstAlign, LLVMValueRef Src, uint SrcAlign, LLVMValueRef Size) => LLVM.BuildMemCpy(this, Dst, DstAlign, Src, SrcAlign, Size);
+
+    public readonly LLVMValueRef BuildMemMove(LLVMValueRef Dst, uint DstAlign, LLVMValueRef Src, uint SrcAlign, LLVMValueRef Size) => LLVM.BuildMemMove(this, Dst, DstAlign, Src, SrcAlign, Size);
+
+    public readonly LLVMValueRef BuildMemSet(LLVMValueRef Ptr, LLVMValueRef Val, LLVMValueRef Len, uint Align) => LLVM.BuildMemSet(this, Ptr, Val, Len, Align);
 
     public readonly LLVMValueRef BuildMul(LLVMValueRef LHS, LLVMValueRef RHS, string Name = "") => BuildMul(LHS, RHS, Name.AsSpan());
 

--- a/sources/LLVMSharp.Interop/Extensions/LLVMComdatRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMComdatRef.cs
@@ -8,6 +8,22 @@ public unsafe partial struct LLVMComdatRef(IntPtr handle) : IEquatable<LLVMComda
 {
     public IntPtr Handle = handle;
 
+    public LLVMComdatSelectionKind SelectionKind
+    {
+        readonly get
+        {
+            return (Handle != IntPtr.Zero) ? LLVM.GetComdatSelectionKind(this) : default;
+        }
+
+        set
+        {
+            if (Handle != IntPtr.Zero)
+            {
+                LLVM.SetComdatSelectionKind(this, value);
+            }
+        }
+    }
+
     public static implicit operator LLVMComdatRef(LLVMComdat* Comdat) => new LLVMComdatRef((IntPtr)Comdat);
 
     public static implicit operator LLVMComdat*(LLVMComdatRef Comdat) => (LLVMComdat*)Comdat.Handle;

--- a/sources/LLVMSharp.Interop/Extensions/LLVMContextRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMContextRef.cs
@@ -29,6 +29,8 @@ public unsafe partial struct LLVMContextRef(IntPtr handle) : IDisposable, IEquat
 
     public readonly LLVMTypeRef Int64Type => (Handle != IntPtr.Zero) ? LLVM.Int64TypeInContext(this) : default;
 
+    public readonly LLVMTypeRef Int128Type => (Handle != IntPtr.Zero) ? LLVM.Int128TypeInContext(this) : default;
+
     public readonly LLVMTypeRef FP128Type => (Handle != IntPtr.Zero) ? LLVM.FP128TypeInContext(this) : default;
 
     public readonly LLVMTypeRef LabelType => (Handle != IntPtr.Zero) ? LLVM.LabelTypeInContext(this) : default;
@@ -40,6 +42,23 @@ public unsafe partial struct LLVMContextRef(IntPtr handle) : IDisposable, IEquat
     public readonly LLVMTypeRef X86FP80Type => (Handle != IntPtr.Zero) ? LLVM.X86FP80TypeInContext(this) : default;
 
     public readonly LLVMTypeRef X86AMXType => (Handle != IntPtr.Zero) ? LLVM.X86AMXTypeInContext(this) : default;
+
+    public readonly LLVMTypeRef MetadataType => (Handle != IntPtr.Zero) ? LLVM.MetadataTypeInContext(this) : default;
+
+    public readonly LLVMTypeRef TokenType => (Handle != IntPtr.Zero) ? LLVM.TokenTypeInContext(this) : default;
+
+    public readonly bool DiscardValueNames
+    {
+        get
+        {
+            return (Handle != IntPtr.Zero) && LLVM.ContextShouldDiscardValueNames(this) != 0;
+        }
+
+        set
+        {
+            LLVM.ContextSetDiscardValueNames(this, value ? 1 : 0);
+        }
+    }
 
     public static implicit operator LLVMContextRef(LLVMOpaqueContext* value) => new LLVMContextRef((IntPtr)value);
 
@@ -102,6 +121,61 @@ public unsafe partial struct LLVMContextRef(IntPtr handle) : IDisposable, IEquat
         return LLVM.CreateStringAttribute(this, marshaledKind, (uint)marshaledKind.Length, marshaledValue, (uint)marshaledValue.Length);
     }
 
+    public readonly LLVMAttributeRef CreateConstantRangeAttribute(uint KindId, uint NumBits, ulong[] LowerWords, ulong[] UpperWords) => CreateConstantRangeAttribute(KindId, NumBits, LowerWords.AsSpan(), UpperWords.AsSpan());
+
+    public readonly LLVMAttributeRef CreateConstantRangeAttribute(uint KindId, uint NumBits, ReadOnlySpan<ulong> LowerWords, ReadOnlySpan<ulong> UpperWords)
+    {
+        fixed (ulong* pLowerWords = LowerWords)
+        fixed (ulong* pUpperWords = UpperWords)
+        {
+            return LLVM.CreateConstantRangeAttribute(this, KindId, NumBits, pLowerWords, pUpperWords);
+        }
+    }
+
+    public readonly LLVMMetadataRef CreateMDNode(LLVMMetadataRef[] MDs) => CreateMDNode(MDs.AsSpan());
+
+    public readonly LLVMMetadataRef CreateMDNode(ReadOnlySpan<LLVMMetadataRef> MDs)
+    {
+        fixed (LLVMMetadataRef* pMDs = MDs)
+        {
+            return LLVM.MDNodeInContext2(this, (LLVMOpaqueMetadata**)pMDs, (nuint)MDs.Length);
+        }
+    }
+
+    public readonly LLVMMetadataRef CreateMDString(string Str) => CreateMDString(Str.AsSpan());
+
+    public readonly LLVMMetadataRef CreateMDString(ReadOnlySpan<char> Str)
+    {
+        using var marshaledStr = new MarshaledString(Str);
+        return LLVM.MDStringInContext2(this, marshaledStr, (nuint)marshaledStr.Length);
+    }
+
+    public readonly LLVMTypeRef CreatePointerType(uint AddressSpace) => LLVM.PointerTypeInContext(this, AddressSpace);
+
+    public readonly LLVMTypeRef CreateTargetExtType(string Name, LLVMTypeRef[] TypeParams, uint[] IntParams) => CreateTargetExtType(Name.AsSpan(), TypeParams.AsSpan(), IntParams.AsSpan());
+
+    public readonly LLVMTypeRef CreateTargetExtType(ReadOnlySpan<char> Name, ReadOnlySpan<LLVMTypeRef> TypeParams, ReadOnlySpan<uint> IntParams)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        fixed (LLVMTypeRef* pTypeParams = TypeParams)
+        fixed (uint* pIntParams = IntParams)
+        {
+            return LLVM.TargetExtTypeInContext(this, marshaledName, (LLVMOpaqueType**)pTypeParams, (uint)TypeParams.Length, pIntParams, (uint)IntParams.Length);
+        }
+    }
+
+    public readonly LLVMMetadataRef CreateTemporaryMDNode(LLVMMetadataRef[] Data) => CreateTemporaryMDNode(Data.AsSpan());
+
+    public readonly LLVMMetadataRef CreateTemporaryMDNode(ReadOnlySpan<LLVMMetadataRef> Data)
+    {
+        fixed (LLVMMetadataRef* pData = Data)
+        {
+            return LLVM.TemporaryMDNode(this, (LLVMOpaqueMetadata**)pData, (nuint)Data.Length);
+        }
+    }
+
+    public readonly LLVMAttributeRef CreateTypeAttribute(uint KindId, LLVMTypeRef TypeRef) => LLVM.CreateTypeAttribute(this, KindId, TypeRef);
+
     public void Dispose()
     {
         if (Handle != IntPtr.Zero)
@@ -145,11 +219,25 @@ public unsafe partial struct LLVMContextRef(IntPtr handle) : IDisposable, IEquat
 
     public override readonly int GetHashCode() => Handle.GetHashCode();
 
+    public readonly delegate* unmanaged[Cdecl]<LLVMOpaqueDiagnosticInfo*, void*, void> GetDiagnosticHandler() => LLVM.ContextGetDiagnosticHandler(this);
+
+    public readonly void* GetDiagnosticContext() => LLVM.ContextGetDiagnosticContext(this);
+
     public readonly LLVMTypeRef GetIntPtrType(LLVMTargetDataRef TD) => LLVM.IntPtrTypeInContext(this, TD);
 
     public readonly LLVMTypeRef GetIntPtrTypeForAS(LLVMTargetDataRef TD, uint AS) => LLVM.IntPtrTypeForASInContext(this, TD, AS);
 
     public readonly LLVMTypeRef GetIntType(uint NumBits) => LLVM.IntTypeInContext(this, NumBits);
+
+    public readonly LLVMTypeRef GetIntrinsicType(uint ID, LLVMTypeRef[] ParamTypes) => GetIntrinsicType(ID, ParamTypes.AsSpan());
+
+    public readonly LLVMTypeRef GetIntrinsicType(uint ID, ReadOnlySpan<LLVMTypeRef> ParamTypes)
+    {
+        fixed (LLVMTypeRef* pParamTypes = ParamTypes)
+        {
+            return LLVM.IntrinsicGetType(this, ID, (LLVMOpaqueType**)pParamTypes, (nuint)ParamTypes.Length);
+        }
+    }
 
     public readonly uint GetMDKindID(string Name, uint SLen) => GetMDKindID(Name.AsSpan(0, (int)SLen));
 
@@ -188,6 +276,22 @@ public unsafe partial struct LLVMContextRef(IntPtr handle) : IDisposable, IEquat
     }
 
     public readonly LLVMBasicBlockRef InsertBasicBlock(LLVMBasicBlockRef BB, string Name) => LLVMBasicBlockRef.InsertInContext(this, BB, Name);
+
+    public readonly uint GetSyncScopeID(string Name) => GetSyncScopeID(Name.AsSpan());
+
+    public readonly uint GetSyncScopeID(ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        return LLVM.GetSyncScopeID(this, marshaledName, (nuint)marshaledName.Length);
+    }
+
+    public readonly LLVMTypeRef GetTypeByName(string Name) => GetTypeByName(Name.AsSpan());
+
+    public readonly LLVMTypeRef GetTypeByName(ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        return LLVM.GetTypeByName2(this, marshaledName);
+    }
 
     public readonly LLVMValueRef MetadataAsValue(LLVMMetadataRef MD) => LLVM.MetadataAsValue(this, MD);
 

--- a/sources/LLVMSharp.Interop/Extensions/LLVMMetadataRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMMetadataRef.cs
@@ -280,6 +280,8 @@ public unsafe partial struct LLVMMetadataRef(IntPtr handle) : IEquatable<LLVMMet
 
     public readonly uint SPFlags => (IsADISubprogram != null) ? llvmsharp.DISubprogram_getSPFlags(this) : default;
 
+    public readonly string Source => (IsADIFile != null) ? LLVM.DIFileGetSource(this) : "";
+
     public readonly string String => (IsAMDString != null) ? llvmsharp.MDString_getString(this) : "";
 
     public readonly ushort Tag => (IsADINode != null) ? LLVM.GetDINodeTag(this) : default;
@@ -326,6 +328,8 @@ public unsafe partial struct LLVMMetadataRef(IntPtr handle) : IEquatable<LLVMMet
 
     public readonly LLVMValueRef AsValue(LLVMContextRef context) => context.MetadataAsValue(this);
 
+    public readonly void DisposeTemporary() => LLVM.DisposeTemporaryMDNode(this);
+
     public override readonly bool Equals(object? obj) => (obj is LLVMMetadataRef other) && Equals(other);
 
     public readonly bool Equals(LLVMMetadataRef other) => this == other;
@@ -366,6 +370,16 @@ public unsafe partial struct LLVMMetadataRef(IntPtr handle) : IEquatable<LLVMMet
     public readonly LLVMMetadataRef[] GetTypeArray()
     {
         return (IsADISubroutineType != null) ? llvmsharp.DISubroutineType_getTypeArray(this) : [];
+    }
+
+    public readonly void ReplaceAllUsesWith(LLVMMetadataRef replacement) => LLVM.MetadataReplaceAllUsesWith(this, replacement);
+
+    public readonly void ReplaceType(LLVMMetadataRef subroutineType)
+    {
+        if (IsADISubprogram != null)
+        {
+            LLVM.DISubprogramReplaceType(this, subroutineType);
+        }
     }
 
     public override readonly string ToString() => $"{nameof(LLVMMetadataRef)}: {Handle:X}";

--- a/sources/LLVMSharp.Interop/Extensions/LLVMModuleRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMModuleRef.cs
@@ -14,6 +14,19 @@ public unsafe partial struct LLVMModuleRef(IntPtr handle) : IDisposable, IEquata
 
     public readonly LLVMContextRef Context => (Handle != IntPtr.Zero) ? LLVM.GetModuleContext(this) : default;
 
+    public readonly LLVMTargetDataRef DataLayoutObject
+    {
+        get
+        {
+            return (Handle != IntPtr.Zero) ? LLVM.GetModuleDataLayout(this) : default;
+        }
+
+        set
+        {
+            LLVM.SetModuleDataLayout(this, value);
+        }
+    }
+
     public readonly string DataLayout
     {
         get
@@ -232,6 +245,14 @@ public unsafe partial struct LLVMModuleRef(IntPtr handle) : IDisposable, IEquata
         return LLVM.AddGlobal(this, Ty, marshaledName);
     }
 
+    public readonly LLVMValueRef AddGlobalIFunc(string Name, LLVMTypeRef Ty, uint AddrSpace, LLVMValueRef Resolver) => AddGlobalIFunc(Name.AsSpan(), Ty, AddrSpace, Resolver);
+
+    public readonly LLVMValueRef AddGlobalIFunc(ReadOnlySpan<char> Name, LLVMTypeRef Ty, uint AddrSpace, LLVMValueRef Resolver)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        return LLVM.AddGlobalIFunc(this, marshaledName, (nuint)marshaledName.Length, Ty, AddrSpace, Resolver);
+    }
+
     public readonly LLVMValueRef AddGlobalInAddressSpace(LLVMTypeRef Ty, string Name, uint AddressSpace) => AddGlobalInAddressSpace(Ty, Name.AsSpan(), AddressSpace);
 
     public readonly LLVMValueRef AddGlobalInAddressSpace(LLVMTypeRef Ty, ReadOnlySpan<char> Name, uint AddressSpace)
@@ -272,6 +293,14 @@ public unsafe partial struct LLVMModuleRef(IntPtr handle) : IDisposable, IEquata
     public readonly LLVMDIBuilderRef CreateDIBuilder()
     {
         return new LLVMDIBuilderRef((IntPtr)LLVM.CreateDIBuilder(this));
+    }
+
+    public readonly void AppendInlineAsm(string Asm) => AppendInlineAsm(Asm.AsSpan());
+
+    public readonly void AppendInlineAsm(ReadOnlySpan<char> Asm)
+    {
+        using var marshaledAsm = new MarshaledString(Asm);
+        LLVM.AppendModuleInlineAsm(this, marshaledAsm, (nuint)marshaledAsm.Length);
     }
 
     public readonly LLVMExecutionEngineRef CreateExecutionEngine()
@@ -345,6 +374,24 @@ public unsafe partial struct LLVMModuleRef(IntPtr handle) : IDisposable, IEquata
 
     public readonly LLVMTypeRef[] GetIdentifiedStructTypes() => llvmsharp.Module_GetIdentifiedStructTypes(this);
 
+    public readonly LLVMValueRef GetIntrinsicDeclaration(uint ID, LLVMTypeRef[] ParamTypes) => GetIntrinsicDeclaration(ID, ParamTypes.AsSpan());
+
+    public readonly LLVMValueRef GetIntrinsicDeclaration(uint ID, ReadOnlySpan<LLVMTypeRef> ParamTypes)
+    {
+        fixed (LLVMTypeRef* pParamTypes = ParamTypes)
+        {
+            return LLVM.GetIntrinsicDeclaration(this, ID, (LLVMOpaqueType**)pParamTypes, (nuint)ParamTypes.Length);
+        }
+    }
+
+    public readonly LLVMMetadataRef GetModuleFlag(string Key) => GetModuleFlag(Key.AsSpan());
+
+    public readonly LLVMMetadataRef GetModuleFlag(ReadOnlySpan<char> Key)
+    {
+        using var marshaledKey = new MarshaledString(Key);
+        return LLVM.GetModuleFlag(this, marshaledKey, (nuint)marshaledKey.Length);
+    }
+
     public readonly LLVMValueRef GetNamedFunction(string Name) => GetNamedFunction(Name.AsSpan());
 
     public readonly LLVMValueRef GetNamedFunction(ReadOnlySpan<char> Name)
@@ -361,6 +408,22 @@ public unsafe partial struct LLVMModuleRef(IntPtr handle) : IDisposable, IEquata
     {
         using var marshaledName = new MarshaledString(Name);
         return LLVM.GetNamedGlobal(this, marshaledName);
+    }
+
+    public readonly LLVMValueRef GetNamedGlobalAlias(string Name) => GetNamedGlobalAlias(Name.AsSpan());
+
+    public readonly LLVMValueRef GetNamedGlobalAlias(ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        return LLVM.GetNamedGlobalAlias(this, marshaledName, (nuint)marshaledName.Length);
+    }
+
+    public readonly LLVMValueRef GetNamedGlobalIFunc(string Name) => GetNamedGlobalIFunc(Name.AsSpan());
+
+    public readonly LLVMValueRef GetNamedGlobalIFunc(ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        return LLVM.GetNamedGlobalIFunc(this, marshaledName, (nuint)marshaledName.Length);
     }
 
     public readonly LLVMValueRef[] GetNamedMetadataOperands(string Name) => GetNamedMetadataOperands(Name.AsSpan());
@@ -387,6 +450,24 @@ public unsafe partial struct LLVMModuleRef(IntPtr handle) : IDisposable, IEquata
     }
 
     public readonly LLVMTypeRef GetTypeByName(string Name) => GetTypeByName(Name.AsSpan());
+
+    public readonly LLVMComdatRef GetOrInsertComdat(string Name) => GetOrInsertComdat(Name.AsSpan());
+
+    public readonly LLVMComdatRef GetOrInsertComdat(ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        return LLVM.GetOrInsertComdat(this, marshaledName);
+    }
+
+    public readonly LLVMNamedMDNodeRef GetOrInsertNamedMetadata(string Name) => GetOrInsertNamedMetadata(Name.AsSpan());
+
+    public readonly LLVMNamedMDNodeRef GetOrInsertNamedMetadata(ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        return LLVM.GetOrInsertNamedMetadata(this, marshaledName, (nuint)marshaledName.Length);
+    }
+
+    public readonly bool Link(LLVMModuleRef Src) => LLVM.LinkModules2(this, Src) == 0;
 
     public readonly LLVMTypeRef GetTypeByName(ReadOnlySpan<char> Name)
     {
@@ -426,7 +507,38 @@ public unsafe partial struct LLVMModuleRef(IntPtr handle) : IDisposable, IEquata
         LLVM.SetModuleInlineAsm(this, marshaledAsm);
     }
 
+    public readonly void RunPasses(string Passes, LLVMTargetMachineRef TM, LLVMPassBuilderOptionsRef Options) => RunPasses(Passes.AsSpan(), TM, Options);
+
+    public readonly void RunPasses(ReadOnlySpan<char> Passes, LLVMTargetMachineRef TM, LLVMPassBuilderOptionsRef Options)
+    {
+        if (!TryRunPasses(Passes, TM, Options, out string ErrorMessage))
+        {
+            throw new ExternalException(ErrorMessage);
+        }
+    }
+
+    public readonly bool StripDebugInfo() => LLVM.StripModuleDebugInfo(this) != 0;
+
     public override readonly string ToString() => (Handle != IntPtr.Zero) ? PrintToString() : string.Empty;
+
+    public readonly bool TryRunPasses(string Passes, LLVMTargetMachineRef TM, LLVMPassBuilderOptionsRef Options, out string OutMessage) => TryRunPasses(Passes.AsSpan(), TM, Options, out OutMessage);
+
+    public readonly bool TryRunPasses(ReadOnlySpan<char> Passes, LLVMTargetMachineRef TM, LLVMPassBuilderOptionsRef Options, out string OutMessage)
+    {
+        using var marshaledPasses = new MarshaledString(Passes);
+        LLVMOpaqueError* error = LLVM.RunPasses(this, marshaledPasses, TM, Options);
+
+        if (error == null)
+        {
+            OutMessage = string.Empty;
+            return true;
+        }
+
+        sbyte* pMessage = LLVM.GetErrorMessage(error);
+        OutMessage = (pMessage != null) ? SpanExtensions.AsString(pMessage) : string.Empty;
+        LLVM.DisposeErrorMessage(pMessage);
+        return false;
+    }
 
     public readonly bool TryCreateExecutionEngine(out LLVMExecutionEngineRef OutEE, out string OutError)
     {

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOperandBundleRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOperandBundleRef.cs
@@ -1,0 +1,65 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOperandBundleRef(IntPtr handle) : IEquatable<LLVMOperandBundleRef>, IDisposable
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOperandBundleRef(LLVMOpaqueOperandBundle* value) => new LLVMOperandBundleRef((IntPtr)value);
+
+    public static implicit operator LLVMOpaqueOperandBundle*(LLVMOperandBundleRef value) => (LLVMOpaqueOperandBundle*)value.Handle;
+
+    public static bool operator ==(LLVMOperandBundleRef left, LLVMOperandBundleRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOperandBundleRef left, LLVMOperandBundleRef right) => !(left == right);
+
+    public readonly uint NumArgs => (Handle != IntPtr.Zero) ? LLVM.GetNumOperandBundleArgs(this) : default;
+
+    public readonly string Tag
+    {
+        get
+        {
+            if (Handle == IntPtr.Zero)
+            {
+                return string.Empty;
+            }
+
+            nuint length = 0;
+            var pTag = LLVM.GetOperandBundleTag(this, &length);
+            return (pTag != null) ? new ReadOnlySpan<byte>(pTag, (int)length).AsString() : string.Empty;
+        }
+    }
+
+    public static LLVMOperandBundleRef Create(string Tag, LLVMValueRef[] Args) => Create(Tag.AsSpan(), Args.AsSpan());
+
+    public static LLVMOperandBundleRef Create(ReadOnlySpan<char> Tag, ReadOnlySpan<LLVMValueRef> Args)
+    {
+        using var marshaledTag = new MarshaledString(Tag);
+        fixed (LLVMValueRef* pArgs = Args)
+        {
+            return LLVM.CreateOperandBundle(marshaledTag, (nuint)marshaledTag.Length, (LLVMOpaqueValue**)pArgs, (uint)Args.Length);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Handle != IntPtr.Zero)
+        {
+            LLVM.DisposeOperandBundle(this);
+            Handle = IntPtr.Zero;
+        }
+    }
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOperandBundleRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOperandBundleRef other) => this == other;
+
+    public readonly LLVMValueRef GetArgAtIndex(uint Index) => LLVM.GetOperandBundleArgAtIndex(this, Index);
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public override readonly string ToString() => $"{nameof(LLVMOperandBundleRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMPassBuilderOptionsRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMPassBuilderOptionsRef.cs
@@ -33,6 +33,14 @@ public unsafe partial struct LLVMPassBuilderOptionsRef(IntPtr handle) : IEquatab
 
     public override readonly int GetHashCode() => Handle.GetHashCode();
 
+    public readonly void SetAAPipeline(string aaPipeline) => SetAAPipeline(aaPipeline.AsSpan());
+
+    public readonly void SetAAPipeline(ReadOnlySpan<char> aaPipeline)
+    {
+        using var marshaledAAPipeline = new MarshaledString(aaPipeline);
+        LLVM.PassBuilderOptionsSetAAPipeline(this, marshaledAAPipeline);
+    }
+
     public readonly void SetCallGraphProfile(bool CallGraphProfile) => LLVM.PassBuilderOptionsSetCallGraphProfile(this, CallGraphProfile ? 1 : 0);
 
     public readonly void SetDebugLogging(bool DebugLogging) => LLVM.PassBuilderOptionsSetDebugLogging(this, DebugLogging ? 1 : 0);

--- a/sources/LLVMSharp.Interop/Extensions/LLVMTargetDataRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMTargetDataRef.cs
@@ -18,6 +18,32 @@ public unsafe partial struct LLVMTargetDataRef(IntPtr handle) : IEquatable<LLVMT
 
     public static LLVMTargetDataRef FromStringRepresentation(ReadOnlySpan<char> stringRep) => LLVM.CreateTargetData(new MarshaledString(stringRep));
 
+    public readonly LLVMByteOrdering ByteOrder => (Handle != IntPtr.Zero) ? LLVM.ByteOrder(this) : default;
+
+    public readonly uint PointerSize => (Handle != IntPtr.Zero) ? LLVM.PointerSize(this) : default;
+
+    public readonly string StringRepresentation
+    {
+        get
+        {
+            if (Handle == IntPtr.Zero)
+            {
+                return string.Empty;
+            }
+
+            var pStr = LLVM.CopyStringRepOfTargetData(this);
+
+            if (pStr == null)
+            {
+                return string.Empty;
+            }
+
+            var result = SpanExtensions.AsString(pStr);
+            LLVM.DisposeMessage(pStr);
+            return result;
+        }
+    }
+
     public override readonly bool Equals(object? obj) => (obj is LLVMTargetDataRef other) && Equals(other);
 
     public readonly bool Equals(LLVMTargetDataRef other) => this == other;
@@ -41,6 +67,8 @@ public unsafe partial struct LLVMTargetDataRef(IntPtr handle) : IEquatable<LLVMT
     public readonly uint PreferredAlignmentOfType(LLVMTypeRef type) => LLVM.PreferredAlignmentOfType(this, type);
 
     public readonly uint PreferredAlignmentOfGlobal(LLVMValueRef globalVar) => LLVM.PreferredAlignmentOfGlobal(this, globalVar);
+
+    public readonly uint PointerSizeForAddressSpace(uint addressSpace) => LLVM.PointerSizeForAS(this, addressSpace);
 
     public override readonly string ToString() => $"{nameof(LLVMTargetDataRef)}: {Handle:X}";
 }

--- a/sources/LLVMSharp.Interop/Extensions/LLVMTargetMachineOptionsRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMTargetMachineOptionsRef.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMTargetMachineOptionsRef(IntPtr handle) : IEquatable<LLVMTargetMachineOptionsRef>, IDisposable
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMTargetMachineOptionsRef(LLVMOpaqueTargetMachineOptions* value) => new LLVMTargetMachineOptionsRef((IntPtr)value);
+
+    public static implicit operator LLVMOpaqueTargetMachineOptions*(LLVMTargetMachineOptionsRef value) => (LLVMOpaqueTargetMachineOptions*)value.Handle;
+
+    public static bool operator ==(LLVMTargetMachineOptionsRef left, LLVMTargetMachineOptionsRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMTargetMachineOptionsRef left, LLVMTargetMachineOptionsRef right) => !(left == right);
+
+    public static LLVMTargetMachineOptionsRef Create() => LLVM.CreateTargetMachineOptions();
+
+    public void Dispose()
+    {
+        if (Handle != IntPtr.Zero)
+        {
+            LLVM.DisposeTargetMachineOptions(this);
+            Handle = IntPtr.Zero;
+        }
+    }
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMTargetMachineOptionsRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMTargetMachineOptionsRef other) => this == other;
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public readonly void SetABI(string abi) => SetABI(abi.AsSpan());
+
+    public readonly void SetABI(ReadOnlySpan<char> abi)
+    {
+        using var marshaledABI = new MarshaledString(abi);
+        LLVM.TargetMachineOptionsSetABI(this, marshaledABI);
+    }
+
+    public readonly void SetCodeGenOptLevel(LLVMCodeGenOptLevel level) => LLVM.TargetMachineOptionsSetCodeGenOptLevel(this, level);
+
+    public readonly void SetCodeModel(LLVMCodeModel codeModel) => LLVM.TargetMachineOptionsSetCodeModel(this, codeModel);
+
+    public readonly void SetCPU(string cpu) => SetCPU(cpu.AsSpan());
+
+    public readonly void SetCPU(ReadOnlySpan<char> cpu)
+    {
+        using var marshaledCPU = new MarshaledString(cpu);
+        LLVM.TargetMachineOptionsSetCPU(this, marshaledCPU);
+    }
+
+    public readonly void SetFeatures(string features) => SetFeatures(features.AsSpan());
+
+    public readonly void SetFeatures(ReadOnlySpan<char> features)
+    {
+        using var marshaledFeatures = new MarshaledString(features);
+        LLVM.TargetMachineOptionsSetFeatures(this, marshaledFeatures);
+    }
+
+    public readonly void SetRelocMode(LLVMRelocMode reloc) => LLVM.TargetMachineOptionsSetRelocMode(this, reloc);
+
+    public override readonly string ToString() => $"{nameof(LLVMTargetMachineOptionsRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMTargetMachineRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMTargetMachineRef.cs
@@ -72,6 +72,28 @@ public unsafe partial struct LLVMTargetMachineRef(IntPtr handle) : IEquatable<LL
 
     public readonly LLVMTargetDataRef CreateTargetDataLayout() => LLVM.CreateTargetDataLayout(this);
 
+    public readonly void AddAnalysisPasses(LLVMPassManagerRef passManager) => LLVM.AddAnalysisPasses(this, passManager);
+
+    public readonly void SetAsmVerbosity(bool verboseAsm) => LLVM.SetTargetMachineAsmVerbosity(this, verboseAsm ? 1 : 0);
+
+    public readonly void SetFastISel(bool enable) => LLVM.SetTargetMachineFastISel(this, enable ? 1 : 0);
+
+    public readonly void SetGlobalISel(bool enable) => LLVM.SetTargetMachineGlobalISel(this, enable ? 1 : 0);
+
+    public readonly void SetGlobalISelAbort(LLVMGlobalISelAbortMode mode) => LLVM.SetTargetMachineGlobalISelAbort(this, mode);
+
+    public readonly void SetMachineOutliner(bool enable) => LLVM.SetTargetMachineMachineOutliner(this, enable ? 1 : 0);
+
+    public readonly LLVMMemoryBufferRef EmitToMemoryBuffer(LLVMModuleRef module, LLVMCodeGenFileType codegen)
+    {
+        if (!TryEmitToMemoryBuffer(module, codegen, out LLVMMemoryBufferRef memoryBuffer, out string Error))
+        {
+            throw new ExternalException(Error);
+        }
+
+        return memoryBuffer;
+    }
+
     public readonly void EmitToFile(LLVMModuleRef module, string fileName, LLVMCodeGenFileType codegen) => EmitToFile(module, fileName.AsSpan(), codegen);
 
     public readonly void EmitToFile(LLVMModuleRef module, ReadOnlySpan<char> fileName, LLVMCodeGenFileType codegen)
@@ -98,6 +120,27 @@ public unsafe partial struct LLVMTargetMachineRef(IntPtr handle) : IEquatable<LL
 
         sbyte* errorMessage = null;
         int result = LLVM.TargetMachineEmitToFile(this, module, marshaledFileName, codegen, &errorMessage);
+
+        if (errorMessage == null)
+        {
+            message = string.Empty;
+        }
+        else
+        {
+            message = SpanExtensions.AsString(errorMessage);
+            LLVM.DisposeErrorMessage(errorMessage);
+        }
+
+        return result == 0;
+    }
+
+    public readonly bool TryEmitToMemoryBuffer(LLVMModuleRef module, LLVMCodeGenFileType codegen, out LLVMMemoryBufferRef memoryBuffer, out string message)
+    {
+        sbyte* errorMessage = null;
+        LLVMOpaqueMemoryBuffer* outMemoryBuffer = null;
+        int result = LLVM.TargetMachineEmitToMemoryBuffer(this, module, codegen, &errorMessage, &outMemoryBuffer);
+
+        memoryBuffer = outMemoryBuffer;
 
         if (errorMessage == null)
         {

--- a/sources/LLVMSharp.Interop/Extensions/LLVMTargetRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMTargetRef.cs
@@ -147,5 +147,13 @@ public unsafe partial struct LLVMTargetRef(IntPtr handle) : IEquatable<LLVMTarge
         return LLVM.CreateTargetMachine(this, marshaledTriple, marshaledCPU, marshaledFeatures, level, reloc, codeModel);
     }
 
+    public readonly LLVMTargetMachineRef CreateTargetMachineWithOptions(string triple, LLVMTargetMachineOptionsRef options) => CreateTargetMachineWithOptions(triple.AsSpan(), options);
+
+    public readonly LLVMTargetMachineRef CreateTargetMachineWithOptions(ReadOnlySpan<char> triple, LLVMTargetMachineOptionsRef options)
+    {
+        using var marshaledTriple = new MarshaledString(triple);
+        return LLVM.CreateTargetMachineWithOptions(this, marshaledTriple, options);
+    }
+
     public override readonly string ToString() => $"{nameof(LLVMTargetRef)}: {Handle:X}";
 }

--- a/sources/LLVMSharp.Interop/Extensions/LLVMTypeRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMTypeRef.cs
@@ -54,6 +54,10 @@ public unsafe partial struct LLVMTypeRef(IntPtr handle) : IEquatable<LLVMTypeRef
 
     public readonly bool IsFunctionVarArg => (Kind == LLVMTypeKind.LLVMFunctionTypeKind) && LLVM.IsFunctionVarArg(this) != 0;
 
+    public readonly bool IsLiteralStruct => (Kind == LLVMTypeKind.LLVMStructTypeKind) && LLVM.IsLiteralStruct(this) != 0;
+
+    public readonly bool IsOpaquePointer => (Kind == LLVMTypeKind.LLVMPointerTypeKind) && LLVM.PointerTypeIsOpaque(this) != 0;
+
     public readonly bool IsOpaqueStruct => (Kind == LLVMTypeKind.LLVMStructTypeKind) && LLVM.IsOpaqueStruct(this) != 0;
 
     public readonly bool IsPackedStruct => (Kind == LLVMTypeKind.LLVMStructTypeKind) && LLVM.IsPackedStruct(this) != 0;
@@ -97,6 +101,24 @@ public unsafe partial struct LLVMTypeRef(IntPtr handle) : IEquatable<LLVMTypeRef
     }
 
     public readonly uint SubtypesCount => (Handle != IntPtr.Zero) ? LLVM.GetNumContainedTypes(this) : default;
+
+    public readonly string TargetExtTypeName
+    {
+        get
+        {
+            if (Kind != LLVMTypeKind.LLVMTargetExtTypeKind)
+            {
+                return string.Empty;
+            }
+
+            var pName = LLVM.GetTargetExtTypeName(this);
+            return (pName != null) ? SpanExtensions.AsString(pName) : string.Empty;
+        }
+    }
+
+    public readonly uint TargetExtTypeNumIntParams => (Kind == LLVMTypeKind.LLVMTargetExtTypeKind) ? LLVM.GetTargetExtTypeNumIntParams(this) : default;
+
+    public readonly uint TargetExtTypeNumTypeParams => (Kind == LLVMTypeKind.LLVMTargetExtTypeKind) ? LLVM.GetTargetExtTypeNumTypeParams(this) : default;
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)] // Justification: causes native allocation
     public readonly LLVMValueRef Undef => (Handle != IntPtr.Zero) ? LLVM.GetUndef(this) : default;
@@ -147,6 +169,34 @@ public unsafe partial struct LLVMTypeRef(IntPtr handle) : IEquatable<LLVMTypeRef
 
     public static LLVMTypeRef CreateScalableVector(LLVMTypeRef ElementType, uint ElementCount) => LLVM.ScalableVectorType(ElementType, ElementCount);
 
+    public readonly LLVMValueRef ConstArray2(LLVMValueRef[] ConstantVals) => ConstArray2(ConstantVals.AsSpan());
+
+    public readonly LLVMValueRef ConstArray2(ReadOnlySpan<LLVMValueRef> ConstantVals)
+    {
+        fixed (LLVMValueRef* pConstantVals = ConstantVals)
+        {
+            return LLVM.ConstArray2(this, (LLVMOpaqueValue**)pConstantVals, (ulong)ConstantVals.Length);
+        }
+    }
+
+    public readonly LLVMValueRef ConstDataArray(ReadOnlySpan<byte> Data)
+    {
+        fixed (byte* pData = Data)
+        {
+            return LLVM.ConstDataArray(this, (sbyte*)pData, (nuint)Data.Length);
+        }
+    }
+
+    public readonly LLVMValueRef ConstGEPWithNoWrapFlags(LLVMValueRef ConstantVal, LLVMValueRef[] ConstantIndices, LLVMGEPNoWrapFlags NoWrapFlags) => ConstGEPWithNoWrapFlags(ConstantVal, ConstantIndices.AsSpan(), NoWrapFlags);
+
+    public readonly LLVMValueRef ConstGEPWithNoWrapFlags(LLVMValueRef ConstantVal, ReadOnlySpan<LLVMValueRef> ConstantIndices, LLVMGEPNoWrapFlags NoWrapFlags)
+    {
+        fixed (LLVMValueRef* pConstantIndices = ConstantIndices)
+        {
+            return LLVM.ConstGEPWithNoWrapFlags(this, ConstantVal, (LLVMOpaqueValue**)pConstantIndices, (uint)ConstantIndices.Length, (uint)NoWrapFlags);
+        }
+    }
+
     public readonly void Dump() => LLVM.DumpType(this);
 
     public override readonly bool Equals(object? obj) => (obj is LLVMTypeRef other) && Equals(other);
@@ -156,6 +206,15 @@ public unsafe partial struct LLVMTypeRef(IntPtr handle) : IEquatable<LLVMTypeRef
     public readonly double GenericValueToFloat(LLVMGenericValueRef GenVal) => LLVM.GenericValueToFloat(this, GenVal);
 
     public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public readonly LLVMValueRef GetInlineAsm(string AsmString, string Constraints, bool HasSideEffects, bool IsAlignStack, LLVMInlineAsmDialect Dialect, bool CanThrow) => GetInlineAsm(AsmString.AsSpan(), Constraints.AsSpan(), HasSideEffects, IsAlignStack, Dialect, CanThrow);
+
+    public readonly LLVMValueRef GetInlineAsm(ReadOnlySpan<char> AsmString, ReadOnlySpan<char> Constraints, bool HasSideEffects, bool IsAlignStack, LLVMInlineAsmDialect Dialect, bool CanThrow)
+    {
+        using var marshaledAsmString = new MarshaledString(AsmString);
+        using var marshaledConstraints = new MarshaledString(Constraints);
+        return LLVM.GetInlineAsm(this, marshaledAsmString, (nuint)marshaledAsmString.Length, marshaledConstraints, (nuint)marshaledConstraints.Length, HasSideEffects ? 1 : 0, IsAlignStack ? 1 : 0, Dialect, CanThrow ? 1 : 0);
+    }
 
     public readonly LLVMTypeRef[] GetParamTypes()
     {
@@ -237,6 +296,10 @@ public unsafe partial struct LLVMTypeRef(IntPtr handle) : IEquatable<LLVMTypeRef
             LLVM.GetSubtypes(this, (LLVMOpaqueType**)pArr);
         }
     }
+
+    public readonly uint GetTargetExtTypeIntParam(uint Idx) => (Kind == LLVMTypeKind.LLVMTargetExtTypeKind) ? LLVM.GetTargetExtTypeIntParam(this, Idx) : default;
+
+    public readonly LLVMTypeRef GetTargetExtTypeTypeParam(uint Idx) => (Kind == LLVMTypeKind.LLVMTargetExtTypeKind) ? LLVM.GetTargetExtTypeTypeParam(this, Idx) : default;
 
     public readonly string PrintToString()
     {

--- a/sources/LLVMSharp.Interop/Extensions/LLVMUseRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMUseRef.cs
@@ -10,6 +10,8 @@ public unsafe partial struct LLVMUseRef(IntPtr handle) : IEquatable<LLVMUseRef>
 
     public readonly LLVMUseRef NextUse => (Handle != IntPtr.Zero) ? LLVM.GetNextUse(this) : default;
 
+    public readonly LLVMValueRef UsedValue => (Handle != IntPtr.Zero) ? LLVM.GetUsedValue(this) : default;
+
     public readonly LLVMValueRef User => (Handle != IntPtr.Zero) ? LLVM.GetUser(this) : default;
 
     public static implicit operator LLVMUseRef(LLVMOpaqueUse* Use) => new LLVMUseRef((IntPtr)Use);

--- a/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMValueRef.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.InteropServices;
 using static LLVMSharp.Interop.LLVMTailCallKind;
 
 namespace LLVMSharp.Interop;
@@ -56,11 +57,28 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
         }
     }
 
+    public readonly uint AtomicSyncScopeID
+    {
+        get
+        {
+            return ((IsALoadInst != null) || (IsAStoreInst != null) || (IsAFenceInst != null) || (IsAAtomicRMWInst != null) || (IsAAtomicCmpXchgInst != null)) ? LLVM.GetAtomicSyncScopeID(this) : default;
+        }
+
+        set
+        {
+            LLVM.SetAtomicSyncScopeID(this, value);
+        }
+    }
+
     public readonly uint BasicBlocksCount => (IsAFunction != null) ? LLVM.CountBasicBlocks(this) : default;
 
     public readonly LLVMBasicBlockRef BlockAddressBasicBlock => (IsABlockAddress != null) ? LLVM.GetBlockAddressBasicBlock(this) : default;
 
     public readonly LLVMValueRef BlockAddressFunction => (IsABlockAddress != null) ? LLVM.GetBlockAddressFunction(this) : default;
+
+    public readonly LLVMBasicBlockRef CallBrDefaultDest => (IsACallBrInst != null) ? LLVM.GetCallBrDefaultDest(this) : default;
+
+    public readonly uint CallBrIndirectDestsCount => (IsACallBrInst != null) ? LLVM.GetCallBrNumIndirectDests(this) : default;
 
     public readonly LLVMTypeRef CalledFunctionType => ((IsACallInst != null) || (IsAInvokeInst != null) || (IsACallBrInst != null)) ? LLVM.GetCalledFunctionType(this) : default;
 
@@ -92,6 +110,19 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
         }
     }
 
+    public readonly LLVMComdatRef Comdat
+    {
+        get
+        {
+            return (IsAGlobalObject != null) ? LLVM.GetComdat(this) : default;
+        }
+
+        set
+        {
+            LLVM.SetComdat(this, value);
+        }
+    }
+
     public readonly LLVMValueRef Condition
     {
         get
@@ -116,6 +147,40 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
     public readonly LLVMContextRef Context => (Handle != IntPtr.Zero) ? LLVM.GetValueContext(this) : default;
 
     public readonly ReadOnlySpan<byte> Data => (IsAConstantDataArray != null) ? llvmsharp.ConstantDataArray_getData(this) : default;
+
+    public readonly uint DebugLocColumn => ((IsAInstruction != null) || (IsAGlobalVariable != null) || (IsAFunction != null)) ? LLVM.GetDebugLocColumn(this) : default;
+
+    public readonly string DebugLocDirectory
+    {
+        get
+        {
+            if ((IsAInstruction == null) && (IsAGlobalVariable == null) && (IsAFunction == null))
+            {
+                return string.Empty;
+            }
+
+            uint length = 0;
+            var pStr = LLVM.GetDebugLocDirectory(this, &length);
+            return (pStr != null) ? new ReadOnlySpan<byte>(pStr, (int)length).AsString() : string.Empty;
+        }
+    }
+
+    public readonly string DebugLocFilename
+    {
+        get
+        {
+            if ((IsAInstruction == null) && (IsAGlobalVariable == null) && (IsAFunction == null))
+            {
+                return string.Empty;
+            }
+
+            uint length = 0;
+            var pStr = LLVM.GetDebugLocFilename(this, &length);
+            return (pStr != null) ? new ReadOnlySpan<byte>(pStr, (int)length).AsString() : string.Empty;
+        }
+    }
+
+    public readonly uint DebugLocLine => ((IsAInstruction != null) || (IsAGlobalVariable != null) || (IsAFunction != null)) ? LLVM.GetDebugLocLine(this) : default;
 
     public readonly string? DemangledName
     {
@@ -270,6 +335,8 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public readonly LLVMMetadataRef GlobalVariableExpression => (IsAGlobalVariable != null) ? llvmsharp.GlobalVariable_getGlobalVariableExpression(this) : default;
 
+    public readonly uint HandlersCount => (IsACatchSwitchInst != null) ? LLVM.GetNumHandlers(this) : default;
+
     public readonly bool HasMetadata => (IsAInstruction != null) && LLVM.HasMetadata(this) != 0;
 
     public readonly bool HasNoSignedWrap
@@ -306,6 +373,10 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public readonly bool HasPersonalityFn => (IsAFunction != null) && LLVM.HasPersonalityFn(this) != 0;
 
+    public readonly bool HasPrefixData => (IsAFunction != null) && LLVM.HasPrefixData(this) != 0;
+
+    public readonly bool HasPrologueData => (IsAFunction != null) && LLVM.HasPrologueData(this) != 0;
+
     public readonly bool HasUnnamedAddr
     {
         get
@@ -339,6 +410,8 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public readonly uint IncomingCount => (IsAPHINode != null) ? LLVM.CountIncoming(this) : default;
 
+    public readonly uint IndicesCount => ((IsAExtractValueInst != null) || (IsAInsertValueInst != null)) ? LLVM.GetNumIndices(this) : default;
+
     public readonly LLVMValueRef Initializer
     {
         get
@@ -349,6 +422,46 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
         set
         {
             LLVM.SetInitializer(this, value);
+        }
+    }
+
+    public readonly bool InlineAsmCanUnwind => (IsAInlineAsm != null) && LLVM.GetInlineAsmCanUnwind(this) != 0;
+
+    public readonly string InlineAsmConstraintString
+    {
+        get
+        {
+            if (IsAInlineAsm == null)
+            {
+                return string.Empty;
+            }
+
+            nuint length = 0;
+            var pStr = LLVM.GetInlineAsmConstraintString(this, &length);
+            return (pStr != null) ? new ReadOnlySpan<byte>(pStr, (int)length).AsString() : string.Empty;
+        }
+    }
+
+    public readonly LLVMInlineAsmDialect InlineAsmDialect => (IsAInlineAsm != null) ? LLVM.GetInlineAsmDialect(this) : default;
+
+    public readonly LLVMTypeRef InlineAsmFunctionType => (IsAInlineAsm != null) ? LLVM.GetInlineAsmFunctionType(this) : default;
+
+    public readonly bool InlineAsmHasSideEffects => (IsAInlineAsm != null) && LLVM.GetInlineAsmHasSideEffects(this) != 0;
+
+    public readonly bool InlineAsmNeedsAlignedStack => (IsAInlineAsm != null) && LLVM.GetInlineAsmNeedsAlignedStack(this) != 0;
+
+    public readonly string InlineAsmString
+    {
+        get
+        {
+            if (IsAInlineAsm == null)
+            {
+                return string.Empty;
+            }
+
+            nuint length = 0;
+            var pStr = LLVM.GetInlineAsmAsmString(this, &length);
+            return (pStr != null) ? new ReadOnlySpan<byte>(pStr, (int)length).AsString() : string.Empty;
         }
     }
 
@@ -558,6 +671,21 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public readonly LLVMValueRef IsAZExtInst => LLVM.IsAZExtInst(this);
 
+    public readonly bool IsAtomic => (IsAInstruction != null) && LLVM.IsAtomic(this) != 0;
+
+    public readonly bool IsAtomicSingleThread
+    {
+        get
+        {
+            return (IsAInstruction != null) && LLVM.IsAtomicSingleThread(this) != 0;
+        }
+
+        set
+        {
+            LLVM.SetAtomicSingleThread(this, value ? 1 : 0);
+        }
+    }
+
     public readonly bool IsBasicBlock => (Handle != IntPtr.Zero) && LLVM.ValueIsBasicBlock(this) != 0;
 
     public readonly bool IsCleanup
@@ -692,6 +820,8 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public readonly uint MDNodeOperandsCount => (IsAMDNode == null) ? LLVM.GetMDNodeNumOperands(this) : default;
 
+    public readonly uint MaskElementsCount => (IsAShuffleVectorInst != null) ? LLVM.GetNumMaskElements(this) : default;
+
     public readonly string Name
     {
         get
@@ -746,11 +876,24 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
         }
     }
 
-    public readonly LLVMBasicBlockRef NormalDest => (IsAInvokeInst != null) ? LLVM.GetNormalDest(this) : default;
+    public readonly LLVMBasicBlockRef NormalDest
+    {
+        get
+        {
+            return (IsAInvokeInst != null) ? LLVM.GetNormalDest(this) : default;
+        }
+
+        set
+        {
+            LLVM.SetNormalDest(this, value);
+        }
+    }
 
     public readonly uint NumClauses => (IsALandingPadInst != null) ? LLVM.GetNumClauses(this) : default;
 
     public readonly LLVMOpcode Opcode => Kind is LLVMValueKind.LLVMInstructionValueKind ? InstructionOpcode : ConstOpcode;
+
+    public readonly uint OperandBundlesCount => ((IsACallInst != null) || (IsAInvokeInst != null) || (IsACallBrInst != null)) ? LLVM.GetNumOperandBundles(this) : default;
 
     public readonly int OperandCount => ((Kind == LLVMValueKind.LLVMMetadataAsValueValueKind) || (IsAUser != null)) ? LLVM.GetNumOperands(this) : default;
 
@@ -771,6 +914,19 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public readonly LLVMValueRef ParamParent => (IsAArgument != null) ? LLVM.GetParamParent(this) : default;
 
+    public readonly LLVMValueRef ParentCatchSwitch
+    {
+        get
+        {
+            return (IsACatchPadInst != null) ? LLVM.GetParentCatchSwitch(this) : default;
+        }
+
+        set
+        {
+            LLVM.SetParentCatchSwitch(this, value);
+        }
+    }
+
     public readonly LLVMValueRef PersonalityFn
     {
         get
@@ -781,6 +937,19 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
         set
         {
             LLVM.SetPersonalityFn(this, value);
+        }
+    }
+
+    public readonly LLVMValueRef PrefixData
+    {
+        get
+        {
+            return HasPrefixData ? LLVM.GetPrefixData(this) : default;
+        }
+
+        set
+        {
+            LLVM.SetPrefixData(this, value);
         }
     }
 
@@ -795,6 +964,19 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
     public readonly LLVMValueRef PreviousParam => (IsAArgument != null) ? LLVM.GetPreviousParam(this) : default;
 
     public readonly LLVMValueRef PreviousFunction => (IsAFunction != null) ? LLVM.GetPreviousFunction(this) : default;
+
+    public readonly LLVMValueRef PrologueData
+    {
+        get
+        {
+            return HasPrologueData ? LLVM.GetPrologueData(this) : default;
+        }
+
+        set
+        {
+            LLVM.SetPrologueData(this, value);
+        }
+    }
 
     public readonly LLVMTypeRef ReturnType => (IsAFunction != null) ? llvmsharp.Function_getReturnType(this) : default;
 
@@ -825,7 +1007,18 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
     }
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)] // Justification: can throw
-    public readonly LLVMMetadataRef Subprogram => (IsAFunction != null) ? LLVM.GetSubprogram(this) : default;
+    public readonly LLVMMetadataRef Subprogram
+    {
+        get
+        {
+            return (IsAFunction != null) ? LLVM.GetSubprogram(this) : default;
+        }
+
+        set
+        {
+            LLVM.SetSubprogram(this, value);
+        }
+    }
 
     public readonly uint SuccessorsCount => (IsAInstruction != null) ? LLVM.GetNumSuccessors(this) : default;
 
@@ -872,7 +1065,18 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
         }
     }
 
-    public readonly LLVMBasicBlockRef UnwindDest => ((IsAInvokeInst != null) || (IsACatchSwitchInst != null) || (IsACleanupReturnInst != null)) ? LLVM.GetUnwindDest(this) : default;
+    public readonly LLVMBasicBlockRef UnwindDest
+    {
+        get
+        {
+            return ((IsAInvokeInst != null) || (IsACatchSwitchInst != null) || (IsACleanupReturnInst != null)) ? LLVM.GetUnwindDest(this) : default;
+        }
+
+        set
+        {
+            LLVM.SetUnwindDest(this, value);
+        }
+    }
 
     public readonly LLVMValueUsesEnumerable Uses => new LLVMValueUsesEnumerable(this);
 
@@ -1191,6 +1395,8 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public readonly void AddDestination(LLVMBasicBlockRef Dest) => LLVM.AddDestination(this, Dest);
 
+    public readonly void AddHandler(LLVMBasicBlockRef Dest) => LLVM.AddHandler(this, Dest);
+
     public readonly void AddIncoming(LLVMValueRef[] IncomingValues, LLVMBasicBlockRef[] IncomingBlocks, uint Count) => AddIncoming(IncomingValues.AsSpan(), IncomingBlocks.AsSpan(), Count);
 
     public readonly void AddIncoming(ReadOnlySpan<LLVMValueRef> IncomingValues, ReadOnlySpan<LLVMBasicBlockRef> IncomingBlocks, uint Count)
@@ -1219,6 +1425,8 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
         return LLVM.AppendBasicBlock(this, marshaledName);
     }
 
+    public readonly void AppendExistingBasicBlock(LLVMBasicBlockRef BB) => LLVM.AppendExistingBasicBlock(this, BB);
+
     public readonly LLVMBasicBlockRef AsBasicBlock() => LLVM.ValueAsBasicBlock(this);
 
     public readonly LLVMMetadataRef AsMetadata() => LLVM.ValueAsMetadata(this);
@@ -1226,6 +1434,8 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
     public readonly void DeleteFunction() => LLVM.DeleteFunction(this);
 
     public readonly void DeleteGlobal() => LLVM.DeleteGlobal(this);
+
+    public readonly void DeleteInstruction() => LLVM.DeleteInstruction(this);
 
     public readonly void Dump() => LLVM.DumpValue(this);
 
@@ -1385,6 +1595,8 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
         LLVM.AddAttributeAtIndex(this, Idx, A);
     }
 
+    public readonly void AddCallSiteAttribute(LLVMAttributeIndex Idx, LLVMAttributeRef A) => LLVM.AddCallSiteAttribute(this, Idx, A);
+
     public readonly LLVMAttributeRef[] GetAttributesAtIndex(LLVMAttributeIndex Idx)
     {
         var Attrs = new LLVMAttributeRef[GetAttributeCountAtIndex(Idx)];
@@ -1401,9 +1613,27 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public readonly LLVMAttributeRef GetEnumAttributeAtIndex(LLVMAttributeIndex Idx, uint KindId) => LLVM.GetEnumAttributeAtIndex(this, Idx, KindId);
 
+    public readonly LLVMAttributeRef GetStringAttributeAtIndex(LLVMAttributeIndex Idx, string K) => GetStringAttributeAtIndex(Idx, K.AsSpan());
+
+    public readonly LLVMAttributeRef GetStringAttributeAtIndex(LLVMAttributeIndex Idx, ReadOnlySpan<char> K)
+    {
+        using var marshaledK = new MarshaledString(K);
+        return LLVM.GetStringAttributeAtIndex(this, Idx, marshaledK, (uint)marshaledK.Length);
+    }
+
     public readonly void RemoveEnumAttributeAtIndex(LLVMAttributeIndex Idx, uint KindId) => LLVM.RemoveEnumAttributeAtIndex(this, Idx, KindId);
 
+    public readonly void RemoveStringAttributeAtIndex(LLVMAttributeIndex Idx, string K) => RemoveStringAttributeAtIndex(Idx, K.AsSpan());
+
+    public readonly void RemoveStringAttributeAtIndex(LLVMAttributeIndex Idx, ReadOnlySpan<char> K)
+    {
+        using var marshaledK = new MarshaledString(K);
+        LLVM.RemoveStringAttributeAtIndex(this, Idx, marshaledK, (uint)marshaledK.Length);
+    }
+
     public readonly LLVMValueRef GetBlockAddress(LLVMBasicBlockRef BB) => LLVM.BlockAddress(this, BB);
+
+    public readonly LLVMBasicBlockRef GetCallBrIndirectDest(uint Idx) => LLVM.GetCallBrIndirectDest(this, Idx);
 
     public readonly uint GetCallSiteAttributeCount(LLVMAttributeIndex Idx) => LLVM.GetCallSiteAttributeCount(this, Idx);
 
@@ -1419,6 +1649,26 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
         return Attrs;
     }
 
+    public readonly LLVMAttributeRef GetCallSiteEnumAttribute(LLVMAttributeIndex Idx, uint KindID) => LLVM.GetCallSiteEnumAttribute(this, Idx, KindID);
+
+    public readonly LLVMAttributeRef GetCallSiteStringAttribute(LLVMAttributeIndex Idx, string K) => GetCallSiteStringAttribute(Idx, K.AsSpan());
+
+    public readonly LLVMAttributeRef GetCallSiteStringAttribute(LLVMAttributeIndex Idx, ReadOnlySpan<char> K)
+    {
+        using var marshaledK = new MarshaledString(K);
+        return LLVM.GetCallSiteStringAttribute(this, Idx, marshaledK, (uint)marshaledK.Length);
+    }
+
+    public readonly void RemoveCallSiteEnumAttribute(LLVMAttributeIndex Idx, uint KindID) => LLVM.RemoveCallSiteEnumAttribute(this, Idx, KindID);
+
+    public readonly void RemoveCallSiteStringAttribute(LLVMAttributeIndex Idx, string K) => RemoveCallSiteStringAttribute(Idx, K.AsSpan());
+
+    public readonly void RemoveCallSiteStringAttribute(LLVMAttributeIndex Idx, ReadOnlySpan<char> K)
+    {
+        using var marshaledK = new MarshaledString(K);
+        LLVM.RemoveCallSiteStringAttribute(this, Idx, marshaledK, (uint)marshaledK.Length);
+    }
+
     public readonly double GetConstRealDouble(out bool losesInfo)
     {
         int losesInfoOut;
@@ -1432,16 +1682,50 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public readonly LLVMValueRef GetArgOperand(uint index) => LLVM.GetArgOperand(this, index);
 
+    public readonly LLVMOpcode GetCastOpcode(bool SrcIsSigned, LLVMTypeRef DestTy, bool DestIsSigned) => LLVM.GetCastOpcode(this, SrcIsSigned ? 1 : 0, DestTy, DestIsSigned ? 1 : 0);
+
     public readonly LLVMValueRef GetClause(uint index) => LLVM.GetClause(this, index);
 
     [Obsolete("Use GetAggregateElement instead")]
     public readonly LLVMValueRef GetElementAsConstant(uint idx) => LLVM.GetElementAsConstant(this, idx);
+
+    public readonly LLVMBasicBlockRef[] GetHandlers()
+    {
+        if (IsACatchSwitchInst == null)
+        {
+            return [];
+        }
+
+        var Handlers = new LLVMBasicBlockRef[LLVM.GetNumHandlers(this)];
+
+        if (Handlers.Length != 0)
+        {
+            fixed (LLVMBasicBlockRef* pHandlers = Handlers)
+            {
+                LLVM.GetHandlers(this, (LLVMOpaqueBasicBlock**)pHandlers);
+            }
+        }
+
+        return Handlers;
+    }
 
     public override readonly int GetHashCode() => Handle.GetHashCode();
 
     public readonly LLVMBasicBlockRef GetIncomingBlock(uint Index) => LLVM.GetIncomingBlock(this, Index);
 
     public readonly LLVMValueRef GetIncomingValue(uint Index) => LLVM.GetIncomingValue(this, Index);
+
+    public readonly ReadOnlySpan<uint> GetIndices()
+    {
+        if ((IsAExtractValueInst == null) && (IsAInsertValueInst == null))
+        {
+            return default;
+        }
+
+        var count = LLVM.GetNumIndices(this);
+        var pIndices = LLVM.GetIndices(this);
+        return (pIndices != null) ? new ReadOnlySpan<uint>(pIndices, (int)count) : default;
+    }
 
     public readonly string GetMDString(out uint Len)
     {
@@ -1459,9 +1743,13 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
         }
     }
 
+    public readonly int GetMaskValue(uint Elt) => (IsAShuffleVectorInst != null) ? LLVM.GetMaskValue(this, Elt) : default;
+
     public readonly LLVMValueRef GetMetadata(uint KindID) => LLVM.GetMetadata(this, KindID);
 
     public readonly LLVMValueRef GetOperand(uint Index) => LLVM.GetOperand(this, Index);
+
+    public readonly LLVMOperandBundleRef GetOperandBundleAtIndex(uint Index) => LLVM.GetOperandBundleAtIndex(this, Index);
 
     public readonly LLVMValueRef[] GetOperands()
     {
@@ -1483,7 +1771,46 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public readonly LLVMValueRef GetParam(uint Index) => LLVM.GetParam(this, Index);
 
+    public readonly ReadOnlySpan<byte> GetRawDataValues()
+    {
+        if (IsAConstantDataSequential == null)
+        {
+            return default;
+        }
+
+        nuint sizeInBytes = 0;
+        var pData = LLVM.GetRawDataValues(this, &sizeInBytes);
+        return (pData != null) ? new ReadOnlySpan<byte>(pData, (int)sizeInBytes) : default;
+    }
+
     public readonly LLVMBasicBlockRef GetSuccessor(uint i) => LLVM.GetSuccessor(this, i);
+
+    public readonly void GlobalClearMetadata() => LLVM.GlobalClearMetadata(this);
+
+    public readonly (uint Kind, LLVMMetadataRef Metadata)[] GlobalCopyAllMetadata()
+    {
+        nuint numEntries = 0;
+        var pEntries = LLVM.GlobalCopyAllMetadata(this, &numEntries);
+
+        if (numEntries == 0)
+        {
+            return [];
+        }
+
+        var entries = new (uint Kind, LLVMMetadataRef Metadata)[numEntries];
+
+        for (uint i = 0; i < numEntries; i++)
+        {
+            entries[i] = (LLVM.ValueMetadataEntriesGetKind(pEntries, i), (LLVMMetadataRef)LLVM.ValueMetadataEntriesGetMetadata(pEntries, i));
+        }
+
+        LLVM.DisposeValueMetadataEntries(pEntries);
+        return entries;
+    }
+
+    public readonly void GlobalEraseMetadata(uint Kind) => LLVM.GlobalEraseMetadata(this, Kind);
+
+    public readonly void GlobalSetMetadata(uint Kind, LLVMMetadataRef MD) => LLVM.GlobalSetMetadata(this, Kind, MD);
 
     public readonly void InstructionEraseFromParent() => LLVM.InstructionEraseFromParent(this);
 
@@ -1507,10 +1834,22 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public readonly void ReplaceMDNodeOperandWith(uint Index, LLVMMetadataRef Replacement) => LLVM.ReplaceMDNodeOperandWith(this, Index, Replacement);
 
+    public readonly void RunPassesOnFunction(string Passes, LLVMTargetMachineRef TM, LLVMPassBuilderOptionsRef Options) => RunPassesOnFunction(Passes.AsSpan(), TM, Options);
+
+    public readonly void RunPassesOnFunction(ReadOnlySpan<char> Passes, LLVMTargetMachineRef TM, LLVMPassBuilderOptionsRef Options)
+    {
+        if (!TryRunPassesOnFunction(Passes, TM, Options, out string ErrorMessage))
+        {
+            throw new ExternalException(ErrorMessage);
+        }
+    }
+
     public void SetAlignment(uint Bytes)
     {
         Alignment = Bytes;
     }
+
+    public readonly void SetArgOperand(uint i, LLVMValueRef value) => LLVM.SetArgOperand(this, i, value);
 
     public readonly void SetInstrParamAlignment(LLVMAttributeIndex index, uint align) => LLVM.SetInstrParamAlignment(this, index, align);
 
@@ -1522,7 +1861,34 @@ public unsafe partial struct LLVMValueRef(IntPtr handle) : IEquatable<LLVMValueR
 
     public readonly void SetSuccessor(uint i, LLVMBasicBlockRef block) => LLVM.SetSuccessor(this, i, block);
 
+    public readonly void SetValueName2(string Name) => SetValueName2(Name.AsSpan());
+
+    public readonly void SetValueName2(ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        LLVM.SetValueName2(this, marshaledName, (nuint)marshaledName.Length);
+    }
+
     public override readonly string ToString() => (Handle != IntPtr.Zero) ? PrintToString() : string.Empty;
+
+    public readonly bool TryRunPassesOnFunction(string Passes, LLVMTargetMachineRef TM, LLVMPassBuilderOptionsRef Options, out string OutMessage) => TryRunPassesOnFunction(Passes.AsSpan(), TM, Options, out OutMessage);
+
+    public readonly bool TryRunPassesOnFunction(ReadOnlySpan<char> Passes, LLVMTargetMachineRef TM, LLVMPassBuilderOptionsRef Options, out string OutMessage)
+    {
+        using var marshaledPasses = new MarshaledString(Passes);
+        LLVMOpaqueError* error = LLVM.RunPassesOnFunction(this, marshaledPasses, TM, Options);
+
+        if (error == null)
+        {
+            OutMessage = string.Empty;
+            return true;
+        }
+
+        sbyte* pMessage = LLVM.GetErrorMessage(error);
+        OutMessage = (pMessage != null) ? SpanExtensions.AsString(pMessage) : string.Empty;
+        LLVM.DisposeErrorMessage(pMessage);
+        return false;
+    }
 
     public readonly bool VerifyFunction(LLVMVerifierFailureAction Action) => LLVM.VerifyFunction(this, Action) == 0;
 


### PR DESCRIPTION
Wraps the remaining CORE LLVM-C accessors on their existing typed-handle structs so the middle layer (Layer 2) exposes the same surface the raw C-API does, rather than forcing callers down to the generated `LLVM.*` P/Invokes.

Covers Use, Comdat, BasicBlock, Type, Context, Module, Builder, Value, Metadata, and the Target/codegen/target-machine-options groups. Two new typed handles are added where the C-API has an opaque type with no wrapper yet: `LLVMTargetMachineOptionsRef` and `LLVMOperandBundleRef`.

No generated-file edits; interop-only. Builds clean (0 warnings) and the full test suite passes (2625).