### PR TITLE
Add typed-handle wrappers for the ORC v2 / LLJIT C-API

### DIFF
--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcDefinitionGeneratorRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcDefinitionGeneratorRef.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcDefinitionGeneratorRef(IntPtr handle) : IDisposable, IEquatable<LLVMOrcDefinitionGeneratorRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcDefinitionGeneratorRef(LLVMOrcOpaqueDefinitionGenerator* value) => new LLVMOrcDefinitionGeneratorRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueDefinitionGenerator*(LLVMOrcDefinitionGeneratorRef value) => (LLVMOrcOpaqueDefinitionGenerator*)value.Handle;
+
+    public static bool operator ==(LLVMOrcDefinitionGeneratorRef left, LLVMOrcDefinitionGeneratorRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcDefinitionGeneratorRef left, LLVMOrcDefinitionGeneratorRef right) => !(left == right);
+
+    public static LLVMOrcDefinitionGeneratorRef CreateCustomCAPIDefinitionGenerator(delegate* unmanaged[Cdecl]<LLVMOrcOpaqueDefinitionGenerator*, void*, LLVMOrcOpaqueLookupState**, LLVMOrcLookupKind, LLVMOrcOpaqueJITDylib*, LLVMOrcJITDylibLookupFlags, LLVMOrcCLookupSetElement*, nuint, LLVMOpaqueError*> F, void* Ctx, delegate* unmanaged[Cdecl]<void*, void> Dispose)
+        => LLVM.OrcCreateCustomCAPIDefinitionGenerator(F, Ctx, Dispose);
+
+    public static LLVMErrorRef CreateDynamicLibrarySearchGeneratorForProcess(out LLVMOrcDefinitionGeneratorRef Result, sbyte GlobalPrefix, delegate* unmanaged[Cdecl]<void*, LLVMOrcOpaqueSymbolStringPoolEntry*, int> Filter, void* FilterCtx)
+    {
+        fixed (LLVMOrcDefinitionGeneratorRef* pResult = &Result)
+        {
+            return LLVM.OrcCreateDynamicLibrarySearchGeneratorForProcess((LLVMOrcOpaqueDefinitionGenerator**)pResult, GlobalPrefix, Filter, FilterCtx);
+        }
+    }
+
+    public static LLVMErrorRef CreateDynamicLibrarySearchGeneratorForPath(out LLVMOrcDefinitionGeneratorRef Result, ReadOnlySpan<char> FileName, sbyte GlobalPrefix, delegate* unmanaged[Cdecl]<void*, LLVMOrcOpaqueSymbolStringPoolEntry*, int> Filter, void* FilterCtx)
+    {
+        using var marshaledFileName = new MarshaledString(FileName);
+
+        fixed (LLVMOrcDefinitionGeneratorRef* pResult = &Result)
+        {
+            return LLVM.OrcCreateDynamicLibrarySearchGeneratorForPath((LLVMOrcOpaqueDefinitionGenerator**)pResult, marshaledFileName, GlobalPrefix, Filter, FilterCtx);
+        }
+    }
+
+    public static LLVMErrorRef CreateStaticLibrarySearchGeneratorForPath(out LLVMOrcDefinitionGeneratorRef Result, LLVMOrcObjectLayerRef ObjLayer, ReadOnlySpan<char> FileName)
+    {
+        using var marshaledFileName = new MarshaledString(FileName);
+
+        fixed (LLVMOrcDefinitionGeneratorRef* pResult = &Result)
+        {
+            return LLVM.OrcCreateStaticLibrarySearchGeneratorForPath((LLVMOrcOpaqueDefinitionGenerator**)pResult, ObjLayer, marshaledFileName);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Handle != IntPtr.Zero)
+        {
+            LLVM.OrcDisposeDefinitionGenerator(this);
+            Handle = IntPtr.Zero;
+        }
+    }
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcDefinitionGeneratorRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcDefinitionGeneratorRef other) => this == other;
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcDefinitionGeneratorRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcDumpObjectsRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcDumpObjectsRef.cs
@@ -1,0 +1,53 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcDumpObjectsRef(IntPtr handle) : IDisposable, IEquatable<LLVMOrcDumpObjectsRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcDumpObjectsRef(LLVMOrcOpaqueDumpObjects* value) => new LLVMOrcDumpObjectsRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueDumpObjects*(LLVMOrcDumpObjectsRef value) => (LLVMOrcOpaqueDumpObjects*)value.Handle;
+
+    public static bool operator ==(LLVMOrcDumpObjectsRef left, LLVMOrcDumpObjectsRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcDumpObjectsRef left, LLVMOrcDumpObjectsRef right) => !(left == right);
+
+    public static LLVMOrcDumpObjectsRef Create(string DumpDir, string IdentifierOverride) => Create(DumpDir.AsSpan(), IdentifierOverride.AsSpan());
+
+    public static LLVMOrcDumpObjectsRef Create(ReadOnlySpan<char> DumpDir, ReadOnlySpan<char> IdentifierOverride)
+    {
+        using var marshaledDumpDir = new MarshaledString(DumpDir);
+        using var marshaledIdentifierOverride = new MarshaledString(IdentifierOverride);
+        return LLVM.OrcCreateDumpObjects(marshaledDumpDir, marshaledIdentifierOverride);
+    }
+
+    // Dumps ObjBuffer and, on success, returns it (possibly replaced) through the ref parameter.
+    public readonly LLVMErrorRef CallOperator(ref LLVMMemoryBufferRef ObjBuffer)
+    {
+        fixed (LLVMMemoryBufferRef* pObjBuffer = &ObjBuffer)
+        {
+            return LLVM.OrcDumpObjects_CallOperator(this, (LLVMOpaqueMemoryBuffer**)pObjBuffer);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Handle != IntPtr.Zero)
+        {
+            LLVM.OrcDisposeDumpObjects(this);
+            Handle = IntPtr.Zero;
+        }
+    }
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcDumpObjectsRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcDumpObjectsRef other) => this == other;
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcDumpObjectsRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcExecutionSessionRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcExecutionSessionRef.cs
@@ -1,0 +1,75 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcExecutionSessionRef(IntPtr handle) : IEquatable<LLVMOrcExecutionSessionRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcExecutionSessionRef(LLVMOrcOpaqueExecutionSession* value) => new LLVMOrcExecutionSessionRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueExecutionSession*(LLVMOrcExecutionSessionRef value) => (LLVMOrcOpaqueExecutionSession*)value.Handle;
+
+    public static bool operator ==(LLVMOrcExecutionSessionRef left, LLVMOrcExecutionSessionRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcExecutionSessionRef left, LLVMOrcExecutionSessionRef right) => !(left == right);
+
+    public readonly LLVMOrcSymbolStringPoolRef SymbolStringPool => (Handle != IntPtr.Zero) ? LLVM.OrcExecutionSessionGetSymbolStringPool(this) : default;
+
+    public readonly LLVMOrcJITDylibRef CreateBareJITDylib(string Name) => CreateBareJITDylib(Name.AsSpan());
+
+    public readonly LLVMOrcJITDylibRef CreateBareJITDylib(ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        return LLVM.OrcExecutionSessionCreateBareJITDylib(this, marshaledName);
+    }
+
+    public readonly LLVMErrorRef CreateJITDylib(out LLVMOrcJITDylibRef Result, string Name) => CreateJITDylib(out Result, Name.AsSpan());
+
+    public readonly LLVMErrorRef CreateJITDylib(out LLVMOrcJITDylibRef Result, ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+
+        fixed (LLVMOrcJITDylibRef* pResult = &Result)
+        {
+            return LLVM.OrcExecutionSessionCreateJITDylib(this, (LLVMOrcOpaqueJITDylib**)pResult, marshaledName);
+        }
+    }
+
+    public readonly LLVMOrcObjectLayerRef CreateRTDyldObjectLinkingLayerWithSectionMemoryManager() => LLVM.OrcCreateRTDyldObjectLinkingLayerWithSectionMemoryManager(this);
+
+    public readonly LLVMOrcObjectLayerRef CreateRTDyldObjectLinkingLayerWithMCJITMemoryManagerLikeCallbacks(void* CreateContextCtx, delegate* unmanaged[Cdecl]<void*, void*> CreateContext, delegate* unmanaged[Cdecl]<void*, void> NotifyTerminating, delegate* unmanaged[Cdecl]<void*, nuint, uint, uint, sbyte*, byte*> AllocateCodeSection, delegate* unmanaged[Cdecl]<void*, nuint, uint, uint, sbyte*, int, byte*> AllocateDataSection, delegate* unmanaged[Cdecl]<void*, sbyte**, int> FinalizeMemory, delegate* unmanaged[Cdecl]<void*, void> Destroy)
+        => LLVM.OrcCreateRTDyldObjectLinkingLayerWithMCJITMemoryManagerLikeCallbacks(this, CreateContextCtx, CreateContext, NotifyTerminating, AllocateCodeSection, AllocateDataSection, FinalizeMemory, Destroy);
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcExecutionSessionRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcExecutionSessionRef other) => this == other;
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public readonly LLVMOrcJITDylibRef GetJITDylibByName(string Name) => GetJITDylibByName(Name.AsSpan());
+
+    public readonly LLVMOrcJITDylibRef GetJITDylibByName(ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        return LLVM.OrcExecutionSessionGetJITDylibByName(this, marshaledName);
+    }
+
+    public readonly LLVMOrcSymbolStringPoolEntryRef Intern(string Name) => Intern(Name.AsSpan());
+
+    public readonly LLVMOrcSymbolStringPoolEntryRef Intern(ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        return LLVM.OrcExecutionSessionIntern(this, marshaledName);
+    }
+
+    // Takes ownership of the symbols in the lookup set. HandleResult is called with the result.
+    public readonly void Lookup(LLVMOrcLookupKind K, LLVMOrcCJITDylibSearchOrderElement* SearchOrder, nuint SearchOrderSize, LLVMOrcCLookupSetElement* Symbols, nuint SymbolsSize, delegate* unmanaged[Cdecl]<LLVMOpaqueError*, LLVMOrcCSymbolMapPair*, nuint, void*, void> HandleResult, void* Ctx)
+        => LLVM.OrcExecutionSessionLookup(this, K, SearchOrder, SearchOrderSize, Symbols, SymbolsSize, HandleResult, Ctx);
+
+    public readonly void SetErrorReporter(delegate* unmanaged[Cdecl]<void*, LLVMOpaqueError*, void> ReportError, void* Ctx) => LLVM.OrcExecutionSessionSetErrorReporter(this, ReportError, Ctx);
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcExecutionSessionRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcIRTransformLayerRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcIRTransformLayerRef.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcIRTransformLayerRef(IntPtr handle) : IEquatable<LLVMOrcIRTransformLayerRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcIRTransformLayerRef(LLVMOrcOpaqueIRTransformLayer* value) => new LLVMOrcIRTransformLayerRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueIRTransformLayer*(LLVMOrcIRTransformLayerRef value) => (LLVMOrcOpaqueIRTransformLayer*)value.Handle;
+
+    public static bool operator ==(LLVMOrcIRTransformLayerRef left, LLVMOrcIRTransformLayerRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcIRTransformLayerRef left, LLVMOrcIRTransformLayerRef right) => !(left == right);
+
+    // Takes ownership of MR and TSM.
+    public readonly void Emit(LLVMOrcMaterializationResponsibilityRef MR, LLVMOrcThreadSafeModuleRef TSM) => LLVM.OrcIRTransformLayerEmit(this, MR, TSM);
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcIRTransformLayerRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcIRTransformLayerRef other) => this == other;
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public readonly void SetTransform(delegate* unmanaged[Cdecl]<void*, LLVMOrcOpaqueThreadSafeModule**, LLVMOrcOpaqueMaterializationResponsibility*, LLVMOpaqueError*> TransformFunction, void* Ctx) => LLVM.OrcIRTransformLayerSetTransform(this, TransformFunction, Ctx);
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcIRTransformLayerRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcIndirectStubsManagerRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcIndirectStubsManagerRef.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcIndirectStubsManagerRef(IntPtr handle) : IDisposable, IEquatable<LLVMOrcIndirectStubsManagerRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcIndirectStubsManagerRef(LLVMOrcOpaqueIndirectStubsManager* value) => new LLVMOrcIndirectStubsManagerRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueIndirectStubsManager*(LLVMOrcIndirectStubsManagerRef value) => (LLVMOrcOpaqueIndirectStubsManager*)value.Handle;
+
+    public static bool operator ==(LLVMOrcIndirectStubsManagerRef left, LLVMOrcIndirectStubsManagerRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcIndirectStubsManagerRef left, LLVMOrcIndirectStubsManagerRef right) => !(left == right);
+
+    public static LLVMOrcIndirectStubsManagerRef CreateLocal(string TargetTriple) => CreateLocal(TargetTriple.AsSpan());
+
+    public static LLVMOrcIndirectStubsManagerRef CreateLocal(ReadOnlySpan<char> TargetTriple)
+    {
+        using var marshaledTriple = new MarshaledString(TargetTriple);
+        return LLVM.OrcCreateLocalIndirectStubsManager(marshaledTriple);
+    }
+
+    public void Dispose()
+    {
+        if (Handle != IntPtr.Zero)
+        {
+            LLVM.OrcDisposeIndirectStubsManager(this);
+            Handle = IntPtr.Zero;
+        }
+    }
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcIndirectStubsManagerRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcIndirectStubsManagerRef other) => this == other;
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcIndirectStubsManagerRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcJITDylibRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcJITDylibRef.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcJITDylibRef(IntPtr handle) : IEquatable<LLVMOrcJITDylibRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcJITDylibRef(LLVMOrcOpaqueJITDylib* value) => new LLVMOrcJITDylibRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueJITDylib*(LLVMOrcJITDylibRef value) => (LLVMOrcOpaqueJITDylib*)value.Handle;
+
+    public static bool operator ==(LLVMOrcJITDylibRef left, LLVMOrcJITDylibRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcJITDylibRef left, LLVMOrcJITDylibRef right) => !(left == right);
+
+    // Takes ownership of DG.
+    public readonly void AddGenerator(LLVMOrcDefinitionGeneratorRef DG) => LLVM.OrcJITDylibAddGenerator(this, DG);
+
+    public readonly LLVMErrorRef Clear() => LLVM.OrcJITDylibClear(this);
+
+    public readonly LLVMOrcResourceTrackerRef CreateResourceTracker() => LLVM.OrcJITDylibCreateResourceTracker(this);
+
+    // Takes ownership of MU.
+    public readonly LLVMErrorRef Define(LLVMOrcMaterializationUnitRef MU) => LLVM.OrcJITDylibDefine(this, MU);
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcJITDylibRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcJITDylibRef other) => this == other;
+
+    public readonly LLVMOrcResourceTrackerRef GetDefaultResourceTracker() => LLVM.OrcJITDylibGetDefaultResourceTracker(this);
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcJITDylibRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcJITTargetMachineBuilderRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcJITTargetMachineBuilderRef.cs
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcJITTargetMachineBuilderRef(IntPtr handle) : IDisposable, IEquatable<LLVMOrcJITTargetMachineBuilderRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcJITTargetMachineBuilderRef(LLVMOrcOpaqueJITTargetMachineBuilder* value) => new LLVMOrcJITTargetMachineBuilderRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueJITTargetMachineBuilder*(LLVMOrcJITTargetMachineBuilderRef value) => (LLVMOrcOpaqueJITTargetMachineBuilder*)value.Handle;
+
+    public static bool operator ==(LLVMOrcJITTargetMachineBuilderRef left, LLVMOrcJITTargetMachineBuilderRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcJITTargetMachineBuilderRef left, LLVMOrcJITTargetMachineBuilderRef right) => !(left == right);
+
+    public readonly string TargetTriple
+    {
+        get
+        {
+            if (Handle == IntPtr.Zero)
+            {
+                return string.Empty;
+            }
+
+            var pTriple = LLVM.OrcJITTargetMachineBuilderGetTargetTriple(this);
+
+            // The caller owns the returned string and must free it with LLVM.DisposeMessage.
+            var result = SpanExtensions.AsString(pTriple);
+            LLVM.DisposeMessage(pTriple);
+            return result;
+        }
+    }
+
+    public static LLVMErrorRef DetectHost(out LLVMOrcJITTargetMachineBuilderRef Result)
+    {
+        fixed (LLVMOrcJITTargetMachineBuilderRef* pResult = &Result)
+        {
+            return LLVM.OrcJITTargetMachineBuilderDetectHost((LLVMOrcOpaqueJITTargetMachineBuilder**)pResult);
+        }
+    }
+
+    // Takes ownership of TM.
+    public static LLVMOrcJITTargetMachineBuilderRef CreateFromTargetMachine(LLVMTargetMachineRef TM) => LLVM.OrcJITTargetMachineBuilderCreateFromTargetMachine(TM);
+
+    public void Dispose()
+    {
+        if (Handle != IntPtr.Zero)
+        {
+            LLVM.OrcDisposeJITTargetMachineBuilder(this);
+            Handle = IntPtr.Zero;
+        }
+    }
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcJITTargetMachineBuilderRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcJITTargetMachineBuilderRef other) => this == other;
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public readonly void SetTargetTriple(string TargetTriple) => SetTargetTriple(TargetTriple.AsSpan());
+
+    public readonly void SetTargetTriple(ReadOnlySpan<char> TargetTriple)
+    {
+        using var marshaledTriple = new MarshaledString(TargetTriple);
+        LLVM.OrcJITTargetMachineBuilderSetTargetTriple(this, marshaledTriple);
+    }
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcJITTargetMachineBuilderRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcLLJITBuilderRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcLLJITBuilderRef.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcLLJITBuilderRef(IntPtr handle) : IDisposable, IEquatable<LLVMOrcLLJITBuilderRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcLLJITBuilderRef(LLVMOrcOpaqueLLJITBuilder* value) => new LLVMOrcLLJITBuilderRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueLLJITBuilder*(LLVMOrcLLJITBuilderRef value) => (LLVMOrcOpaqueLLJITBuilder*)value.Handle;
+
+    public static bool operator ==(LLVMOrcLLJITBuilderRef left, LLVMOrcLLJITBuilderRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcLLJITBuilderRef left, LLVMOrcLLJITBuilderRef right) => !(left == right);
+
+    public static LLVMOrcLLJITBuilderRef Create() => LLVM.OrcCreateLLJITBuilder();
+
+    public void Dispose()
+    {
+        if (Handle != IntPtr.Zero)
+        {
+            LLVM.OrcDisposeLLJITBuilder(this);
+            Handle = IntPtr.Zero;
+        }
+    }
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcLLJITBuilderRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcLLJITBuilderRef other) => this == other;
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    // Takes ownership of JTMB.
+    public readonly void SetJITTargetMachineBuilder(LLVMOrcJITTargetMachineBuilderRef JTMB) => LLVM.OrcLLJITBuilderSetJITTargetMachineBuilder(this, JTMB);
+
+    public readonly void SetObjectLinkingLayerCreator(delegate* unmanaged[Cdecl]<void*, LLVMOrcOpaqueExecutionSession*, sbyte*, LLVMOrcOpaqueObjectLayer*> F, void* Ctx) => LLVM.OrcLLJITBuilderSetObjectLinkingLayerCreator(this, F, Ctx);
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcLLJITBuilderRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcLLJITRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcLLJITRef.cs
@@ -1,0 +1,93 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcLLJITRef(IntPtr handle) : IDisposable, IEquatable<LLVMOrcLLJITRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcLLJITRef(LLVMOrcOpaqueLLJIT* value) => new LLVMOrcLLJITRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueLLJIT*(LLVMOrcLLJITRef value) => (LLVMOrcOpaqueLLJIT*)value.Handle;
+
+    public static bool operator ==(LLVMOrcLLJITRef left, LLVMOrcLLJITRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcLLJITRef left, LLVMOrcLLJITRef right) => !(left == right);
+
+    public readonly LLVMOrcExecutionSessionRef ExecutionSession => (Handle != IntPtr.Zero) ? LLVM.OrcLLJITGetExecutionSession(this) : default;
+
+    public readonly LLVMOrcJITDylibRef MainJITDylib => (Handle != IntPtr.Zero) ? LLVM.OrcLLJITGetMainJITDylib(this) : default;
+
+    public readonly LLVMOrcObjectLayerRef ObjLinkingLayer => (Handle != IntPtr.Zero) ? LLVM.OrcLLJITGetObjLinkingLayer(this) : default;
+
+    public readonly LLVMOrcObjectTransformLayerRef ObjTransformLayer => (Handle != IntPtr.Zero) ? LLVM.OrcLLJITGetObjTransformLayer(this) : default;
+
+    public readonly LLVMOrcIRTransformLayerRef IRTransformLayer => (Handle != IntPtr.Zero) ? LLVM.OrcLLJITGetIRTransformLayer(this) : default;
+
+    public readonly sbyte GlobalPrefix => (Handle != IntPtr.Zero) ? LLVM.OrcLLJITGetGlobalPrefix(this) : default;
+
+    // The returned string is owned by the LLJIT instance and must not be freed by the caller.
+    public readonly string TripleString => (Handle != IntPtr.Zero) ? SpanExtensions.AsString(LLVM.OrcLLJITGetTripleString(this)) : string.Empty;
+
+    // The returned string is owned by the LLJIT instance and must not be freed by the caller.
+    public readonly string DataLayoutStr => (Handle != IntPtr.Zero) ? SpanExtensions.AsString(LLVM.OrcLLJITGetDataLayoutStr(this)) : string.Empty;
+
+    public static LLVMErrorRef Create(out LLVMOrcLLJITRef Result, LLVMOrcLLJITBuilderRef Builder)
+    {
+        fixed (LLVMOrcLLJITRef* pResult = &Result)
+        {
+            return LLVM.OrcCreateLLJIT((LLVMOrcOpaqueLLJIT**)pResult, Builder);
+        }
+    }
+
+    public readonly LLVMErrorRef AddObjectFile(LLVMOrcJITDylibRef JD, LLVMMemoryBufferRef ObjBuffer) => LLVM.OrcLLJITAddObjectFile(this, JD, ObjBuffer);
+
+    public readonly LLVMErrorRef AddObjectFileWithRT(LLVMOrcResourceTrackerRef RT, LLVMMemoryBufferRef ObjBuffer) => LLVM.OrcLLJITAddObjectFileWithRT(this, RT, ObjBuffer);
+
+    // Takes ownership of TSM.
+    public readonly LLVMErrorRef AddLLVMIRModule(LLVMOrcJITDylibRef JD, LLVMOrcThreadSafeModuleRef TSM) => LLVM.OrcLLJITAddLLVMIRModule(this, JD, TSM);
+
+    // Takes ownership of TSM.
+    public readonly LLVMErrorRef AddLLVMIRModuleWithRT(LLVMOrcResourceTrackerRef RT, LLVMOrcThreadSafeModuleRef TSM) => LLVM.OrcLLJITAddLLVMIRModuleWithRT(this, RT, TSM);
+
+    public void Dispose()
+    {
+        if (Handle != IntPtr.Zero)
+        {
+            _ = LLVM.OrcDisposeLLJIT(this);
+            Handle = IntPtr.Zero;
+        }
+    }
+
+    public readonly LLVMErrorRef EnableDebugSupport() => LLVM.OrcLLJITEnableDebugSupport(this);
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcLLJITRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcLLJITRef other) => this == other;
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public readonly LLVMErrorRef Lookup(out ulong Result, string Name) => Lookup(out Result, Name.AsSpan());
+
+    public readonly LLVMErrorRef Lookup(out ulong Result, ReadOnlySpan<char> Name)
+    {
+        using var marshaledName = new MarshaledString(Name);
+
+        fixed (ulong* pResult = &Result)
+        {
+            return LLVM.OrcLLJITLookup(this, pResult, marshaledName);
+        }
+    }
+
+    public readonly LLVMOrcSymbolStringPoolEntryRef MangleAndIntern(string UnmangledName) => MangleAndIntern(UnmangledName.AsSpan());
+
+    public readonly LLVMOrcSymbolStringPoolEntryRef MangleAndIntern(ReadOnlySpan<char> UnmangledName)
+    {
+        using var marshaledName = new MarshaledString(UnmangledName);
+        return LLVM.OrcLLJITMangleAndIntern(this, marshaledName);
+    }
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcLLJITRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcLazyCallThroughManagerRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcLazyCallThroughManagerRef.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcLazyCallThroughManagerRef(IntPtr handle) : IDisposable, IEquatable<LLVMOrcLazyCallThroughManagerRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcLazyCallThroughManagerRef(LLVMOrcOpaqueLazyCallThroughManager* value) => new LLVMOrcLazyCallThroughManagerRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueLazyCallThroughManager*(LLVMOrcLazyCallThroughManagerRef value) => (LLVMOrcOpaqueLazyCallThroughManager*)value.Handle;
+
+    public static bool operator ==(LLVMOrcLazyCallThroughManagerRef left, LLVMOrcLazyCallThroughManagerRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcLazyCallThroughManagerRef left, LLVMOrcLazyCallThroughManagerRef right) => !(left == right);
+
+    public static LLVMErrorRef CreateLocal(string TargetTriple, LLVMOrcExecutionSessionRef ES, ulong ErrorHandlerAddr, out LLVMOrcLazyCallThroughManagerRef Result) => CreateLocal(TargetTriple.AsSpan(), ES, ErrorHandlerAddr, out Result);
+
+    public static LLVMErrorRef CreateLocal(ReadOnlySpan<char> TargetTriple, LLVMOrcExecutionSessionRef ES, ulong ErrorHandlerAddr, out LLVMOrcLazyCallThroughManagerRef Result)
+    {
+        using var marshaledTriple = new MarshaledString(TargetTriple);
+
+        fixed (LLVMOrcLazyCallThroughManagerRef* pResult = &Result)
+        {
+            return LLVM.OrcCreateLocalLazyCallThroughManager(marshaledTriple, ES, ErrorHandlerAddr, (LLVMOrcOpaqueLazyCallThroughManager**)pResult);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Handle != IntPtr.Zero)
+        {
+            LLVM.OrcDisposeLazyCallThroughManager(this);
+            Handle = IntPtr.Zero;
+        }
+    }
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcLazyCallThroughManagerRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcLazyCallThroughManagerRef other) => this == other;
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcLazyCallThroughManagerRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcLookupStateRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcLookupStateRef.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcLookupStateRef(IntPtr handle) : IEquatable<LLVMOrcLookupStateRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcLookupStateRef(LLVMOrcOpaqueLookupState* value) => new LLVMOrcLookupStateRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueLookupState*(LLVMOrcLookupStateRef value) => (LLVMOrcOpaqueLookupState*)value.Handle;
+
+    public static bool operator ==(LLVMOrcLookupStateRef left, LLVMOrcLookupStateRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcLookupStateRef left, LLVMOrcLookupStateRef right) => !(left == right);
+
+    public readonly void ContinueLookup(LLVMErrorRef Err) => LLVM.OrcLookupStateContinueLookup(this, Err);
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcLookupStateRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcLookupStateRef other) => this == other;
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcLookupStateRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcMaterializationResponsibilityRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcMaterializationResponsibilityRef.cs
@@ -1,0 +1,86 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcMaterializationResponsibilityRef(IntPtr handle) : IDisposable, IEquatable<LLVMOrcMaterializationResponsibilityRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcMaterializationResponsibilityRef(LLVMOrcOpaqueMaterializationResponsibility* value) => new LLVMOrcMaterializationResponsibilityRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueMaterializationResponsibility*(LLVMOrcMaterializationResponsibilityRef value) => (LLVMOrcOpaqueMaterializationResponsibility*)value.Handle;
+
+    public static bool operator ==(LLVMOrcMaterializationResponsibilityRef left, LLVMOrcMaterializationResponsibilityRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcMaterializationResponsibilityRef left, LLVMOrcMaterializationResponsibilityRef right) => !(left == right);
+
+    public readonly LLVMOrcExecutionSessionRef ExecutionSession => (Handle != IntPtr.Zero) ? LLVM.OrcMaterializationResponsibilityGetExecutionSession(this) : default;
+
+    public readonly LLVMOrcSymbolStringPoolEntryRef InitializerSymbol => (Handle != IntPtr.Zero) ? LLVM.OrcMaterializationResponsibilityGetInitializerSymbol(this) : default;
+
+    public readonly LLVMOrcJITDylibRef TargetDylib => (Handle != IntPtr.Zero) ? LLVM.OrcMaterializationResponsibilityGetTargetDylib(this) : default;
+
+    // Frees a symbol flags map returned by GetSymbols.
+    public static void DisposeCSymbolFlagsMap(LLVMOrcCSymbolFlagsMapPair* Pairs) => LLVM.OrcDisposeCSymbolFlagsMap(Pairs);
+
+    // Frees a symbols array returned by GetRequestedSymbols.
+    public static void DisposeSymbols(LLVMOrcOpaqueSymbolStringPoolEntry** Symbols) => LLVM.OrcDisposeSymbols(Symbols);
+
+    // Takes ownership of the flags in Pairs.
+    public readonly LLVMErrorRef DefineMaterializing(LLVMOrcCSymbolFlagsMapPair* Pairs, nuint NumPairs) => LLVM.OrcMaterializationResponsibilityDefineMaterializing(this, Pairs, NumPairs);
+
+    // Transfers the given symbols to a new MaterializationResponsibility returned through Result.
+    public readonly LLVMErrorRef Delegate(LLVMOrcOpaqueSymbolStringPoolEntry** Symbols, nuint NumSymbols, out LLVMOrcMaterializationResponsibilityRef Result)
+    {
+        fixed (LLVMOrcMaterializationResponsibilityRef* pResult = &Result)
+        {
+            return LLVM.OrcMaterializationResponsibilityDelegate(this, Symbols, NumSymbols, (LLVMOrcOpaqueMaterializationResponsibility**)pResult);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Handle != IntPtr.Zero)
+        {
+            LLVM.OrcDisposeMaterializationResponsibility(this);
+            Handle = IntPtr.Zero;
+        }
+    }
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcMaterializationResponsibilityRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcMaterializationResponsibilityRef other) => this == other;
+
+    public readonly void FailMaterialization() => LLVM.OrcMaterializationResponsibilityFailMaterialization(this);
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    // The returned map is owned by the caller and must be freed with DisposeCSymbolFlagsMap.
+    public readonly LLVMOrcCSymbolFlagsMapPair* GetSymbols(out nuint NumPairs)
+    {
+        fixed (nuint* pNumPairs = &NumPairs)
+        {
+            return LLVM.OrcMaterializationResponsibilityGetSymbols(this, pNumPairs);
+        }
+    }
+
+    // The returned array is owned by the caller and must be freed with DisposeSymbols.
+    public readonly LLVMOrcOpaqueSymbolStringPoolEntry** GetRequestedSymbols(out nuint NumSymbols)
+    {
+        fixed (nuint* pNumSymbols = &NumSymbols)
+        {
+            return LLVM.OrcMaterializationResponsibilityGetRequestedSymbols(this, pNumSymbols);
+        }
+    }
+
+    public readonly LLVMErrorRef NotifyEmitted(LLVMOrcCSymbolDependenceGroup* SymbolDepGroups, nuint NumSymbolDepGroups) => LLVM.OrcMaterializationResponsibilityNotifyEmitted(this, SymbolDepGroups, NumSymbolDepGroups);
+
+    public readonly LLVMErrorRef NotifyResolved(LLVMOrcCSymbolMapPair* Symbols, nuint NumPairs) => LLVM.OrcMaterializationResponsibilityNotifyResolved(this, Symbols, NumPairs);
+
+    // Takes ownership of MU.
+    public readonly LLVMErrorRef Replace(LLVMOrcMaterializationUnitRef MU) => LLVM.OrcMaterializationResponsibilityReplace(this, MU);
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcMaterializationResponsibilityRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcMaterializationUnitRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcMaterializationUnitRef.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcMaterializationUnitRef(IntPtr handle) : IDisposable, IEquatable<LLVMOrcMaterializationUnitRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcMaterializationUnitRef(LLVMOrcOpaqueMaterializationUnit* value) => new LLVMOrcMaterializationUnitRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueMaterializationUnit*(LLVMOrcMaterializationUnitRef value) => (LLVMOrcOpaqueMaterializationUnit*)value.Handle;
+
+    public static bool operator ==(LLVMOrcMaterializationUnitRef left, LLVMOrcMaterializationUnitRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcMaterializationUnitRef left, LLVMOrcMaterializationUnitRef right) => !(left == right);
+
+    // Takes ownership of the pairs in Syms and of InitSym.
+    public static LLVMOrcMaterializationUnitRef CreateCustom(ReadOnlySpan<char> Name, void* Ctx, LLVMOrcCSymbolFlagsMapPair* Syms, nuint NumSyms, LLVMOrcSymbolStringPoolEntryRef InitSym, delegate* unmanaged[Cdecl]<void*, LLVMOrcOpaqueMaterializationResponsibility*, void> Materialize, delegate* unmanaged[Cdecl]<void*, LLVMOrcOpaqueJITDylib*, LLVMOrcOpaqueSymbolStringPoolEntry*, void> Discard, delegate* unmanaged[Cdecl]<void*, void> Destroy)
+    {
+        using var marshaledName = new MarshaledString(Name);
+        return LLVM.OrcCreateCustomMaterializationUnit(marshaledName, Ctx, Syms, NumSyms, InitSym, Materialize, Discard, Destroy);
+    }
+
+    // Takes ownership of the pairs in Syms.
+    public static LLVMOrcMaterializationUnitRef AbsoluteSymbols(LLVMOrcCSymbolMapPair* Syms, nuint NumPairs) => LLVM.OrcAbsoluteSymbols(Syms, NumPairs);
+
+    // Takes ownership of the aliases in CallableAliases.
+    public static LLVMOrcMaterializationUnitRef LazyReexports(LLVMOrcLazyCallThroughManagerRef LCTM, LLVMOrcIndirectStubsManagerRef ISM, LLVMOrcJITDylibRef SourceRef, LLVMOrcCSymbolAliasMapPair* CallableAliases, nuint NumPairs) => LLVM.OrcLazyReexports(LCTM, ISM, SourceRef, CallableAliases, NumPairs);
+
+    public void Dispose()
+    {
+        if (Handle != IntPtr.Zero)
+        {
+            LLVM.OrcDisposeMaterializationUnit(this);
+            Handle = IntPtr.Zero;
+        }
+    }
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcMaterializationUnitRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcMaterializationUnitRef other) => this == other;
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcMaterializationUnitRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcObjectLayerRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcObjectLayerRef.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcObjectLayerRef(IntPtr handle) : IDisposable, IEquatable<LLVMOrcObjectLayerRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcObjectLayerRef(LLVMOrcOpaqueObjectLayer* value) => new LLVMOrcObjectLayerRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueObjectLayer*(LLVMOrcObjectLayerRef value) => (LLVMOrcOpaqueObjectLayer*)value.Handle;
+
+    public static bool operator ==(LLVMOrcObjectLayerRef left, LLVMOrcObjectLayerRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcObjectLayerRef left, LLVMOrcObjectLayerRef right) => !(left == right);
+
+    // Takes ownership of ObjBuffer.
+    public readonly LLVMErrorRef AddObjectFile(LLVMOrcJITDylibRef JD, LLVMMemoryBufferRef ObjBuffer) => LLVM.OrcObjectLayerAddObjectFile(this, JD, ObjBuffer);
+
+    // Takes ownership of ObjBuffer.
+    public readonly LLVMErrorRef AddObjectFileWithRT(LLVMOrcResourceTrackerRef RT, LLVMMemoryBufferRef ObjBuffer) => LLVM.OrcObjectLayerAddObjectFileWithRT(this, RT, ObjBuffer);
+
+    public void Dispose()
+    {
+        if (Handle != IntPtr.Zero)
+        {
+            LLVM.OrcDisposeObjectLayer(this);
+            Handle = IntPtr.Zero;
+        }
+    }
+
+    // Takes ownership of R and ObjBuffer.
+    public readonly void Emit(LLVMOrcMaterializationResponsibilityRef R, LLVMMemoryBufferRef ObjBuffer) => LLVM.OrcObjectLayerEmit(this, R, ObjBuffer);
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcObjectLayerRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcObjectLayerRef other) => this == other;
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public readonly void RegisterJITEventListener(LLVMJITEventListenerRef Listener) => LLVM.OrcRTDyldObjectLinkingLayerRegisterJITEventListener(this, Listener);
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcObjectLayerRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcObjectTransformLayerRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcObjectTransformLayerRef.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcObjectTransformLayerRef(IntPtr handle) : IEquatable<LLVMOrcObjectTransformLayerRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcObjectTransformLayerRef(LLVMOrcOpaqueObjectTransformLayer* value) => new LLVMOrcObjectTransformLayerRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueObjectTransformLayer*(LLVMOrcObjectTransformLayerRef value) => (LLVMOrcOpaqueObjectTransformLayer*)value.Handle;
+
+    public static bool operator ==(LLVMOrcObjectTransformLayerRef left, LLVMOrcObjectTransformLayerRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcObjectTransformLayerRef left, LLVMOrcObjectTransformLayerRef right) => !(left == right);
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcObjectTransformLayerRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcObjectTransformLayerRef other) => this == other;
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public readonly void SetTransform(delegate* unmanaged[Cdecl]<void*, LLVMOpaqueMemoryBuffer**, LLVMOpaqueError*> TransformFunction, void* Ctx) => LLVM.OrcObjectTransformLayerSetTransform(this, TransformFunction, Ctx);
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcObjectTransformLayerRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcResourceTrackerRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcResourceTrackerRef.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcResourceTrackerRef(IntPtr handle) : IEquatable<LLVMOrcResourceTrackerRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcResourceTrackerRef(LLVMOrcOpaqueResourceTracker* value) => new LLVMOrcResourceTrackerRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueResourceTracker*(LLVMOrcResourceTrackerRef value) => (LLVMOrcOpaqueResourceTracker*)value.Handle;
+
+    public static bool operator ==(LLVMOrcResourceTrackerRef left, LLVMOrcResourceTrackerRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcResourceTrackerRef left, LLVMOrcResourceTrackerRef right) => !(left == right);
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcResourceTrackerRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcResourceTrackerRef other) => this == other;
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public readonly void Release() => LLVM.OrcReleaseResourceTracker(this);
+
+    public readonly LLVMErrorRef Remove() => LLVM.OrcResourceTrackerRemove(this);
+
+    public readonly void TransferTo(LLVMOrcResourceTrackerRef DstRT) => LLVM.OrcResourceTrackerTransferTo(this, DstRT);
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcResourceTrackerRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcSymbolStringPoolEntryRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcSymbolStringPoolEntryRef.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcSymbolStringPoolEntryRef(IntPtr handle) : IEquatable<LLVMOrcSymbolStringPoolEntryRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcSymbolStringPoolEntryRef(LLVMOrcOpaqueSymbolStringPoolEntry* value) => new LLVMOrcSymbolStringPoolEntryRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueSymbolStringPoolEntry*(LLVMOrcSymbolStringPoolEntryRef value) => (LLVMOrcOpaqueSymbolStringPoolEntry*)value.Handle;
+
+    public static bool operator ==(LLVMOrcSymbolStringPoolEntryRef left, LLVMOrcSymbolStringPoolEntryRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcSymbolStringPoolEntryRef left, LLVMOrcSymbolStringPoolEntryRef right) => !(left == right);
+
+    // The returned c-string is owned by the pool entry and remains valid until the entry is released.
+    public readonly string Str => (Handle != IntPtr.Zero) ? SpanExtensions.AsString(LLVM.OrcSymbolStringPoolEntryStr(this)) : string.Empty;
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcSymbolStringPoolEntryRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcSymbolStringPoolEntryRef other) => this == other;
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public readonly void Release() => LLVM.OrcReleaseSymbolStringPoolEntry(this);
+
+    public readonly void Retain() => LLVM.OrcRetainSymbolStringPoolEntry(this);
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcSymbolStringPoolEntryRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcSymbolStringPoolRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcSymbolStringPoolRef.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcSymbolStringPoolRef(IntPtr handle) : IEquatable<LLVMOrcSymbolStringPoolRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcSymbolStringPoolRef(LLVMOrcOpaqueSymbolStringPool* value) => new LLVMOrcSymbolStringPoolRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueSymbolStringPool*(LLVMOrcSymbolStringPoolRef value) => (LLVMOrcOpaqueSymbolStringPool*)value.Handle;
+
+    public static bool operator ==(LLVMOrcSymbolStringPoolRef left, LLVMOrcSymbolStringPoolRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcSymbolStringPoolRef left, LLVMOrcSymbolStringPoolRef right) => !(left == right);
+
+    public readonly void ClearDeadEntries() => LLVM.OrcSymbolStringPoolClearDeadEntries(this);
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcSymbolStringPoolRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcSymbolStringPoolRef other) => this == other;
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcSymbolStringPoolRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcThreadSafeContextRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcThreadSafeContextRef.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcThreadSafeContextRef(IntPtr handle) : IDisposable, IEquatable<LLVMOrcThreadSafeContextRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcThreadSafeContextRef(LLVMOrcOpaqueThreadSafeContext* value) => new LLVMOrcThreadSafeContextRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueThreadSafeContext*(LLVMOrcThreadSafeContextRef value) => (LLVMOrcOpaqueThreadSafeContext*)value.Handle;
+
+    public static bool operator ==(LLVMOrcThreadSafeContextRef left, LLVMOrcThreadSafeContextRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcThreadSafeContextRef left, LLVMOrcThreadSafeContextRef right) => !(left == right);
+
+    public static LLVMOrcThreadSafeContextRef Create() => LLVM.OrcCreateNewThreadSafeContext();
+
+    public static LLVMOrcThreadSafeContextRef CreateFromContext(LLVMContextRef Ctx) => LLVM.OrcCreateNewThreadSafeContextFromLLVMContext(Ctx);
+
+    public void Dispose()
+    {
+        if (Handle != IntPtr.Zero)
+        {
+            LLVM.OrcDisposeThreadSafeContext(this);
+            Handle = IntPtr.Zero;
+        }
+    }
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcThreadSafeContextRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcThreadSafeContextRef other) => this == other;
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcThreadSafeContextRef)}: {Handle:X}";
+}

--- a/sources/LLVMSharp.Interop/Extensions/LLVMOrcThreadSafeModuleRef.cs
+++ b/sources/LLVMSharp.Interop/Extensions/LLVMOrcThreadSafeModuleRef.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+
+namespace LLVMSharp.Interop;
+
+public unsafe partial struct LLVMOrcThreadSafeModuleRef(IntPtr handle) : IDisposable, IEquatable<LLVMOrcThreadSafeModuleRef>
+{
+    public IntPtr Handle = handle;
+
+    public static implicit operator LLVMOrcThreadSafeModuleRef(LLVMOrcOpaqueThreadSafeModule* value) => new LLVMOrcThreadSafeModuleRef((IntPtr)value);
+
+    public static implicit operator LLVMOrcOpaqueThreadSafeModule*(LLVMOrcThreadSafeModuleRef value) => (LLVMOrcOpaqueThreadSafeModule*)value.Handle;
+
+    public static bool operator ==(LLVMOrcThreadSafeModuleRef left, LLVMOrcThreadSafeModuleRef right) => left.Handle == right.Handle;
+
+    public static bool operator !=(LLVMOrcThreadSafeModuleRef left, LLVMOrcThreadSafeModuleRef right) => !(left == right);
+
+    // Takes ownership of M.
+    public static LLVMOrcThreadSafeModuleRef Create(LLVMModuleRef M, LLVMOrcThreadSafeContextRef TSCtx) => LLVM.OrcCreateNewThreadSafeModule(M, TSCtx);
+
+    public void Dispose()
+    {
+        if (Handle != IntPtr.Zero)
+        {
+            LLVM.OrcDisposeThreadSafeModule(this);
+            Handle = IntPtr.Zero;
+        }
+    }
+
+    public override readonly bool Equals(object? obj) => (obj is LLVMOrcThreadSafeModuleRef other) && Equals(other);
+
+    public readonly bool Equals(LLVMOrcThreadSafeModuleRef other) => this == other;
+
+    public override readonly int GetHashCode() => Handle.GetHashCode();
+
+    public readonly LLVMErrorRef WithModuleDo(delegate* unmanaged[Cdecl]<void*, LLVMOpaqueModule*, LLVMOpaqueError*> F, void* Ctx) => LLVM.OrcThreadSafeModuleWithModuleDo(this, F, Ctx);
+
+    public override readonly string ToString() => $"{nameof(LLVMOrcThreadSafeModuleRef)}: {Handle:X}";
+}


### PR DESCRIPTION
Adds typed-handle wrappers for the ORC v2 / LLJIT C-API — all 92 `LLVMOrc*` functions across 20 new structs, so the ORC JIT surface is usable from the middle layer instead of the raw generated `LLVM.*` P/Invokes.

The `LLVMOrc*Ref` typedefs previously had no Layer-2 struct (generated code used the raw `LLVMOrcOpaque*` pointers), so each new struct gets the standard implicit conversions to/from the opaque pointer plus the equality/GetHashCode/ToString boilerplate.

New structs: LLJIT, LLJITBuilder, ThreadSafeContext, ThreadSafeModule, JITTargetMachineBuilder, ExecutionSession, JITDylib, ResourceTracker, SymbolStringPool(+Entry), ObjectLayer, IRTransformLayer, ObjectTransformLayer, IndirectStubsManager, LazyCallThroughManager, DumpObjects, DefinitionGenerator, LookupState, MaterializationUnit, MaterializationResponsibility.

Conventions: errors surfaced as `LLVMErrorRef`; Dispose* → IDisposable (the LLJIT dispose discards its error return via `_ =`); retain/release exposed as explicit methods rather than auto-refcounting; function-pointer params (error reporter, transforms, custom generator/MU, memory-manager callbacks) exposed as `delegate* unmanaged[Cdecl]<...>` matching the extern signatures; ownership-transfer / caller-owned / pooled-no-dispose semantics documented inline where subtle.

`LLVMOrcThreadSafeContextGetContext` is not present in this LLVM-C surface, so ThreadSafeContext intentionally has no get-context member.

Interop-only; no generated-file edits. Builds clean (0 warnings), 2625 tests pass.